### PR TITLE
BTA-1832 Update external ID section with sender update information

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The senders model stores information about who sends the money for the transacti
 
 If your site already does KYC on the senders, then let us know as we might waive the requirement to send us sender documents to ease the usage of our API. Otherwise you will have to send us documents for each sender which we will validate.
 
-As with transactions, external IDs can also be included for senders when a transaction is created. If this ID already exists in our system, the transaction will fail to validate.
+As with transactions, external IDs can also be included for senders when a transaction is created. If this ID already exists in our system, any details sent along with the external ID are used to update the sender.
 
 You can read more on creating senders in the [Transaction flow documentation](transaction-flow.md).
 

--- a/transaction-flow.md
+++ b/transaction-flow.md
@@ -186,7 +186,8 @@ The `external_id` field is optional, allowing you to add a custom ID for the sen
 * Only an `id` is provided - we will search for the corresponding sender and use this reference.
 * An `id` is provided along with additional fields - we will update the corresponding sender with the information contained as parameters if the id exists on our system. Otherwise an error will be returned if the `id` does not exist.
 * Only an `external_id` is provided - we will search for the corresponding sender and use this reference.
-* An `external_id` is provided along with additional fields - we will create a new sender with this reference. This process is subject to duplicate validation, and an error will be returned with the corresponding sender if a duplicate `external_id` is found to already exist on our system.
+* An `external_id` is provided along with additional fields - we will create a new sender with this reference. This process is subject to duplicate validation, and an error will be returned with the corresponding sender if a duplicate `external_id` is found to already exist on our system.\
+An exception to this is if the `external_id` is provided along with additional fields **when a transaction is being created**. In this case, any details sent along with the external ID are used to update the sender.
 
 Please note that sending both an `id` and `external_id` at once is invalid and will result in an error.
 


### PR DESCRIPTION
https://btcafrica.atlassian.net/browse/BTA-1832

During transaction creation a sender is now updated with the submitted details if the external ID already exists in our database.
This updates the documentation to reflect this.