### PR TITLE
BTA-2078 Add XOF::Bank payout details

### DIFF
--- a/transaction-flow.md
+++ b/transaction-flow.md
@@ -563,7 +563,7 @@ tigo
 ```
 
 ##### XOF::Bank
-Currently in beta phase. We currently offer this in Senegal and Benin.
+Please note that XOF::Bank payouts are currently in beta phase. At this time, we offer payouts to accounts in Senegal and Benin only.
 
 ```javascript
 "details" : {

--- a/transaction-flow.md
+++ b/transaction-flow.md
@@ -20,6 +20,7 @@
         - [MAD::Cash](#madcash)
         - [XOF::Mobile](#xofmobile)
         - [XOF::Cash](#xofcash)
+        - [XOF::Bank](#xofbank)
     - [Metadata](#metadata)
     - [External ID](#external-id)
   - [Transaction object](#transaction-object)
@@ -559,6 +560,26 @@ The valid `mobile_provider` values are:
 ```
 orange
 tigo
+```
+
+##### XOF::Bank
+Currently in beta phase. We currently offer this in Senegal and Benin.
+
+```javascript
+"details" : {
+  "first_name": "First",
+  "last_name": "Last",
+  "bank_name": "BRM",
+  "bank_account": "SN144-12345",
+  "bank_country": "SN" // "SN" or "BJ"
+}
+```
+
+The valid `bank_country` values are:
+
+```
+SN
+BJ
 ```
 
 ### Metadata


### PR DESCRIPTION
Add payout method details for XOF::Bank to API documentation. Highlights that the payout method is in beta phase with initial rollout in Senegal and Benin.

Resolves: https://btcafrica.atlassian.net/browse/BTA-2078