### PR TITLE
BTA-2078 Add XOF bank payout details

### DIFF
--- a/transaction-flow.md
+++ b/transaction-flow.md
@@ -20,6 +20,7 @@
         - [MAD::Cash](#madcash)
         - [XOF::Mobile](#xofmobile)
         - [XOF::Cash](#xofcash)
+        - [XOF::Bank](#xofbank)
     - [Metadata](#metadata)
     - [External ID](#external-id)
   - [Transaction object](#transaction-object)
@@ -559,6 +560,26 @@ The valid `mobile_provider` values are:
 ```
 orange
 tigo
+```
+
+##### XOF::Bank
+Please note that XOF::Bank payouts are currently in beta phase. At this time, we offer payouts to accounts in Senegal and Benin only.
+
+```javascript
+"details" : {
+  "first_name": "First",
+  "last_name": "Last",
+  "bank_name": "BRM",
+  "bank_account": "SN144-12345",
+  "bank_country": "SN" // "SN" or "BJ"
+}
+```
+
+The valid `bank_country` values are:
+
+```
+SN
+BJ
 ```
 
 ### Metadata

--- a/transaction-flow.md
+++ b/transaction-flow.md
@@ -570,7 +570,7 @@ Please note that XOF::Bank payouts are currently in beta phase. At this time, we
   "first_name": "First",
   "last_name": "Last",
   "bank_name": "BRM",
-  "bank_account": "SN144-12345",
+  "iban": "SN08SN0000000000000000000000",
   "bank_country": "SN" // "SN" or "BJ"
 }
 ```


### PR DESCRIPTION
Add payout method details for XOF::Bank to API documentation. Highlights that the payout method is in beta phase with initial rollout in Senegal and Benin.

Resolves: https://btcafrica.atlassian.net/browse/BTA-2078