### PR TITLE
BTA-3139 Update api documentation to include GBP::Bank FP payout options

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -6,8 +6,12 @@ permalink: /docs/changelog/
 * Table of contents
 {:toc}
 
-Current version of the API is `1.5.0`
-Current version of the SDKs are `1.5.0`
+Current version of the API is `1.7.0`
+Current version of the SDKs are `1.7.0`
+
+1.7.0
+-----
+* Add support for bank account and sort code for the `GBP::Bank` corridor.
 
 1.5.0
 -----

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -219,10 +219,10 @@ For EUR IBAN transfers please use:
 
 For GBP::Bank there are two payout options available:
 
-1. GBP Faster Payments
+1. GBP Payments with account number and sort code
 2. GBP IBAN transfers
 
-For GBP Faster Payments, only the recipient's account number and sort code is sent:
+For GBP Payments with account number and sort code please use:
 
 {% capture data-raw %}
 ```javascript
@@ -252,7 +252,7 @@ For GBP IBAN transfers please use:
 ```
 {% endcapture %}
 
-{% include language-tabbar.html prefix="gbp-bank-details" raw=data-raw %}
+{% include language-tabbar.html prefix="gbp-bank-iban-details" raw=data-raw %}
 
 <div class="alert alert-warning" markdown="1">
 **Warning!** If the recipient account is not an `GBP` account then the recipient's bank might charge for converting the received funds from `GBP` to the local currency.
@@ -261,7 +261,7 @@ For GBP IBAN transfers please use:
 <div class="alert alert-info" markdown="1">
 **Note!**
 
-* You can only make use of one of the above options at a time, i.e you can only use either of GBP Faster payment or GBP IBAN transfer method but not both.
+* The customer needs to enter either an IBAN (and an optional BIC), or an account number and sort code.
 * Transfer is done using the fastest method available on the recipient's bank.
 * If the recipient's bank is in the UK, and supports the Faster Payment network funds will arrive within 2 hours (but usually within a couple minutes)
 * If the recipient's bank supports the SEPA system, funds will arrive within 1-2 business days

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -217,6 +217,27 @@ For EUR IBAN transfers please use:
 
 ## GBP::Bank
 
+For GBP::Bank there are two payout options available:
+
+1. GBP Faster Payments
+2. GBP IBAN transfers
+
+For GBP Faster Payments, only the recipient's account number and sort code is sent:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "first_name": "First",
+  "last_name": "Last",
+  "bank_name": "Lloyds Bank",
+  "bank_account": "12345678",
+  "sort_code": "123456"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="gbp-bank-details" raw=data-raw %}
+
 For GBP IBAN transfers please use:
 
 {% capture data-raw %}
@@ -238,8 +259,10 @@ For GBP IBAN transfers please use:
 </div>
 
 <div class="alert alert-info" markdown="1">
-**Note!** Transfer is done using the fastest method available on the recipient's bank.
+**Note!**
 
+* You can only make use of one of the above options at a time, i.e you can only use either of GBP Faster payment or GBP IBAN transfer method but not both.
+* Transfer is done using the fastest method available on the recipient's bank.
 * If the recipient's bank is in the UK, and supports the Faster Payment network funds will arrive within 2 hours (but usually within a couple minutes)
 * If the recipient's bank supports the SEPA system, funds will arrive within 1-2 business days
 * If the recipient's bank only supports the Swift system, funds will arrive within 2-5 business days


### PR DESCRIPTION
BTA-3139: Update the TZ0 documetation

Changes
-------

Changes include making sure the docs contain support for sort code and account number for GBP::Bank

![Screen Shot 2020-05-27 at 3 30 39 PM](https://user-images.githubusercontent.com/19914657/83033471-0f5ece80-a02f-11ea-9dbf-69683b2de623.png)
