### PR TITLE
BTA-3866 Update changelog versions

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -6,8 +6,13 @@ permalink: /docs/changelog/
 * Table of contents
 {:toc}
 
-Current version of the API is `1.7.0`
-Current version of the SDKs are `1.7.0`
+Current version of the API is `1.8.0`
+Current version of the SDKs are `1.8.0`
+
+1.8.0
+-----
+* Add support for the `ZAR::Bank` corridor.
+* Add support for `MAD::Cash` corridor to send sender fields on the `Sender` object.
 
 1.7.0
 -----


### PR DESCRIPTION
BTA-3866 Update changelog versions
![Screenshot 2020-09-14 at 19 26 48](https://user-images.githubusercontent.com/40179292/93118334-6fea4800-f6c0-11ea-8b6a-9a5e80a93c6c.png)
