### PR TITLE
BTA-5305-Update-processing-state-description-in-docs.transferzero.com

### DIFF
--- a/_docs/transaction-flow.md
+++ b/_docs/transaction-flow.md
@@ -1136,6 +1136,7 @@ The state of the transaction, which can be one of the following:
 * `initial`: Transaction is created, but not yet ready to receive payments (waiting for Sender to be KYC'd and approved).
 * `approved`: Transaction is created and the sender is approved. Payment can be received
 * `pending`: Transaction has received a payin, and it's waiting for the funds to clear.
+* `processing`: Transaction is under compliance review. Please expect feedback in 24 hours or less.
 * `received`: Transaction has received the correct payin amount and will start processing the payouts.
 * `mispaid`: Transaction received funds, but not the requested amount. The transaction will be resized, and will start payout based on the received funds.
 * `manual`: Some of the payments to the recipients have run into issues. Please check the recipient statuses for more information.


### PR DESCRIPTION
This PR adds a transaction processing state with related explanation to the TZero documentation.

![API-Docs processing](https://user-images.githubusercontent.com/40522592/105016510-0483fe80-5a43-11eb-8c13-43635780ce10.png)

Link to Jira ticket:
https://azafinance.atlassian.net/browse/BTA-5305