### PR TITLE
BTA-5460-add-country-to-xof-cash-payout-details

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -6,8 +6,12 @@ permalink: /docs/changelog/
 * Table of contents
 {:toc}
 
-Current version of the API is `1.11.0`
-Current version of the SDKs are `1.11.0`
+Current version of the API is `1.12.0`
+Current version of the SDKs are `1.12.0`
+
+1.12.0
+-----
+* Add support for specifying country for the `XOF::Cash` corridor
 
 1.11.0
 -----

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -430,7 +430,8 @@ For Wizall cash pickup requests please use:
 "details": {
   "first_name": "First",
   "last_name": "Last",
-  "phone_number": "774044436", // local Senegalese format
+  "phone_number": "221774044436", // local or international format
+  "country": "SN", // Optional
   "cash_provider": "wizall" // Mandatory
 }
 ```


### PR DESCRIPTION
- Add optional country attribute to XOF cash payout details