### PR TITLE
BTA-5712 - Unable to create MAD:Cash transaction when identification_type = "O"

### DIFF
--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -332,7 +332,7 @@ For Cashplus cash pickup requests please use:
 {% include language-tabbar.html prefix="mad-cash-details" raw=data-raw %}
 
 Due to regulatory reasons all senders trying to create `MAD::Cash` transactions need to have the following details present:
-- `"identification_type" => "O"` - Values: `"O"`: Other, `"PP"`: Passport, `"ID"`: National ID
+- `"identification_type" => "OT"` - Values: `"OT"`: Other, `"PP"`: Passport, `"ID"`: National ID
 - `"identification_number" => "AB12345678"`
 - `"city_of_birth" => "London"`
 - `"country_of_birth" => "GB"` - ISO 2-letter format


### PR DESCRIPTION
BTA-5712 - Unable to create MAD:Cash transaction when identification_type = "O"

Fix example values for identification_type in MAD::Cash payout details, so it matches the spec:

https://github.com/bitpesa/bitpesa-api-specification/blob/master/definitions/sender.yaml#L146