### PR TITLE
BTA-5460-add-country-to-xof-cash-payout-details

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -6,8 +6,12 @@ permalink: /docs/changelog/
 * Table of contents
 {:toc}
 
-Current version of the API is `1.11.0`
-Current version of the SDKs are `1.11.0`
+Current version of the API is `1.12.0`
+Current version of the SDKs are `1.12.0`
+
+1.12.0
+-----
+* Add support for specifying country for the `XOF::Cash` corridor
 
 1.11.0
 -----

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -430,7 +430,8 @@ For Wizall cash pickup requests please use:
 "details": {
   "first_name": "First",
   "last_name": "Last",
-  "phone_number": "774044436", // local Senegalese format
+  "phone_number": "221774044436", // local or international format
+  "country": "SN", // Optional
   "cash_provider": "wizall" // Mandatory
 }
 ```

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -446,13 +446,25 @@ For Wizall cash pickup requests please use:
   "first_name": "First",
   "last_name": "Last",
   "phone_number": "221774044436", // local or international format
-  "country": "SN", // Optional
+  "country": "CI", // Optional; Default value is "SN"
   "cash_provider": "wizall" // Mandatory
 }
 ```
 {% endcapture %}
 
 {% include language-tabbar.html prefix="xof-cash-details" raw=data-raw %}
+
+The valid `country` values are:
+
+{% capture data-raw %}
+```
+CI
+ML
+SN
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xof-bank-country-values" raw=data-raw %}
 
 All senders trying to create Wizall cash pickup requests need to have the following details present:
 - `"identification_type" => "ID"` - Values: `"PP"`: Passport, `"ID"`: National ID


### PR DESCRIPTION
- Add wizall XOF cash country options to documentation

<img width="645" alt="Screenshot 2021-03-04 at 17 44 26" src="https://user-images.githubusercontent.com/38510016/110006246-517d1500-7d11-11eb-969a-25258471c225.png">

DO NOT MERGE - until Wizall CI and ML are tested and stable