### PR TITLE
BTA-5456 Add CI payouts for XOF::Mobile

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -7,7 +7,12 @@ permalink: /docs/changelog/
 {:toc}
 
 Current version of the API is `1`
-Current version of the SDKs are `1.12.2`
+Current version of the SDKs are `1.13.0`
+
+1.13.0
+-----
+* Add support for the `GHS::Cash` corridor
+* Add support for `XOF::Mobile` payouts to Ivory Coast
 
 1.12.2
 -----

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -481,7 +481,7 @@ For mobile payouts to Senegal and Ivory Coast, please use:
   "first_name": "First",
   "last_name": "Last",
   "mobile_provider": "orange", // lowercase, see supported providers below
-  "phone_number": "0535456361", // mobile number in local country format
+  "phone_number": "774044436", // mobile number in local country format
   "country": "SN" // "SN" for Senegal (default), "CI" for Ivory Coast
 }
 ```

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -480,7 +480,7 @@ For mobile payouts to Senegal and Ivory Coast, please use:
 "details": {
   "first_name": "First",
   "last_name": "Last",
-  "mobile_provider": "orange", // lowercase, see supported providers below
+  "mobile_provider": "orange", // lowercase, see provider values below
   "phone_number": "774044436", // mobile number in local country format
   "country": "SN" // "SN" for Senegal (default), "CI" for Ivory Coast
 }

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -443,6 +443,42 @@ Please note that the fields above are generally considered optional for senders 
 
 ## XOF::Mobile
 
+### Ivory Coast
+
+For Ivory Coast mobile payments please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "first_name": "First",
+  "last_name": "Last",
+  "mobile_provider": "moov", // "moov", "mtn" or "orange"
+  "phone_number": "0535456361", // local Ivory Coast format
+  "country": "CI" // mandatory for Ivory Coast mobile payments
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xof-mobile-details" raw=data-raw %}
+
+The valid `mobile_provider` values for Ivory Coast are:
+
+{% capture data-raw %}
+```
+moov
+mtn
+orange
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xof-mobile-providers" raw=data-raw %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning** `XOF::Mobile` payouts to **Ivory Coast** are currently in beta phase.
+</div>
+
+### Senegal
+
 For Senegalese mobile payments please use:
 
 {% capture data-raw %}
@@ -451,14 +487,15 @@ For Senegalese mobile payments please use:
   "first_name": "First",
   "last_name": "Last",
   "mobile_provider": "orange", // "orange" or "tigo"
-  "phone_number": "774044436" // local Senegalese format
+  "phone_number": "774044436", // local Senegalese format
+  "country": "SN" // optional for Senegalese mobile payments
 }
 ```
 {% endcapture %}
 
 {% include language-tabbar.html prefix="xof-mobile-details" raw=data-raw %}
 
-The valid `mobile_provider` values are:
+The valid `mobile_provider` values for Senegal are:
 
 {% capture data-raw %}
 ```

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -480,9 +480,9 @@ For mobile payouts to Senegal and Ivory Coast, please use:
 "details": {
   "first_name": "First",
   "last_name": "Last",
-  "mobile_provider": "moov", // lowercase, see supported providers below
+  "mobile_provider": "orange", // lowercase, see supported providers below
   "phone_number": "0535456361", // mobile number in local country format
-  "country": "CI" // "SN" for Senegal, "CI" for Ivory Coast
+  "country": "SN" // "SN" for Senegal (default), "CI" for Ivory Coast
 }
 ```
 {% endcapture %}

--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -473,52 +473,16 @@ Please note that the fields above are generally considered optional for senders 
 
 ## XOF::Mobile
 
-### Ivory Coast
-
-For Ivory Coast mobile payments please use:
+For mobile payouts to Senegal and Ivory Coast, please use:
 
 {% capture data-raw %}
 ```javascript
 "details": {
   "first_name": "First",
   "last_name": "Last",
-  "mobile_provider": "moov", // "moov", "mtn" or "orange"
-  "phone_number": "0535456361", // local Ivory Coast format
-  "country": "CI" // mandatory for Ivory Coast mobile payments
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="xof-mobile-details" raw=data-raw %}
-
-The valid `mobile_provider` values for Ivory Coast are:
-
-{% capture data-raw %}
-```
-moov
-mtn
-orange
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="xof-mobile-providers" raw=data-raw %}
-
-<div class="alert alert-warning" markdown="1">
-**Warning** `XOF::Mobile` payouts to **Ivory Coast** are currently in beta phase.
-</div>
-
-### Senegal
-
-For Senegalese mobile payments please use:
-
-{% capture data-raw %}
-```javascript
-"details": {
-  "first_name": "First",
-  "last_name": "Last",
-  "mobile_provider": "orange", // "orange" or "tigo"
-  "phone_number": "774044436", // local Senegalese format
-  "country": "SN" // optional for Senegalese mobile payments
+  "mobile_provider": "moov", // lowercase, see supported providers below
+  "phone_number": "0535456361", // mobile number in local country format
+  "country": "CI" // "SN" for Senegal, "CI" for Ivory Coast
 }
 ```
 {% endcapture %}
@@ -535,6 +499,22 @@ tigo
 {% endcapture %}
 
 {% include language-tabbar.html prefix="xof-mobile-providers" raw=data-raw %}
+
+The valid `mobile_provider` values for Ivory Coast are:
+
+{% capture data-raw %}
+```
+moov
+mtn
+orange
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xof-mobile-providers" raw=data-raw %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning** `XOF::Mobile` payouts to **Ivory Coast** are currently in beta phase.
+</div>
 
 ## XOF::Bank
 


### PR DESCRIPTION
![Screenshot 2021-04-07 at 13 25 58](https://user-images.githubusercontent.com/38947438/113866235-fbced900-97a4-11eb-9f95-04c44d37d273.png)

Add documentation covering XOF::Mobile payouts in Ivory Coast, including
the addition of a new (optional) country field for XOF::Mobile payouts
to Senegal.

Related to: https://azafinance.atlassian.net/browse/BTA-5456