### PR TITLE
Note on XOF:Mobile Ivory Coast Orange amounts

### DIFF
--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -491,6 +491,10 @@ orange
 
 {% include language-tabbar.html prefix="xof-mobile-providers" raw=data-raw %}
 
+<div class="alert alert-info" markdown="1">
+**Note** Amounts for `XOF::Mobile` payouts to **Ivory Coast 'Orange'** mobile numbers should be multiples of 5.
+</div>
+
 <div class="alert alert-warning" markdown="1">
 **Warning** `XOF::Mobile` payouts to **Ivory Coast** are currently in beta phase.
 </div>


### PR DESCRIPTION
Note indicating that amounts for XOF:Mobile Ivory Coast Orange payouts should be multiple of 5.