### PR TITLE
Add note regarding XOF::Mobile CI Orange payouts

### DIFF
--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -491,6 +491,10 @@ orange
 
 {% include language-tabbar.html prefix="xof-mobile-providers" raw=data-raw %}
 
+<div class="alert alert-info" markdown="1">
+**Note** Amounts for `XOF::Mobile` payouts to **Ivory Coast 'Orange'** mobile numbers should be multiples of 5.
+</div>
+
 <div class="alert alert-warning" markdown="1">
 **Warning** `XOF::Mobile` payouts to **Ivory Coast** are currently in beta phase.
 </div>


### PR DESCRIPTION
Add a note explaining that for XOF::Mobile payouts to Cote D'Ivoire,
where Orange is the provider, the amount value should be divisible by 5.

Replicates this PR, which has been stuck in CI build state as pending:
https://github.com/transferzero/api-documentation/pull/59