### PR TITLE
Remove optional sender fields for MAD::Cash

### DIFF
--- a/_docs/payout-details.md
+++ b/_docs/payout-details.md
@@ -346,8 +346,6 @@ For Cashplus cash pickup requests please use:
 Due to regulatory reasons all senders trying to create `MAD::Cash` transactions need to have the following details present:
 - `"identification_type" => "OT"` - Values: `"OT"`: Other, `"PP"`: Passport, `"ID"`: National ID
 - `"identification_number" => "AB12345678"`
-- `"city_of_birth" => "London"`
-- `"country_of_birth" => "GB"` - ISO 2-letter format
 - `"gender" => "M"` - Values: `"M"`: Male, `"F"`: Female
 
 Please note that the fields above are generally considered optional for senders for other payment corridors. If you wish to use an existing sender who has some of these fields missing you can provide them alongside the `id` or `external_id` field in the sender details. For example:


### PR DESCRIPTION
Remove optional sender fields for MAD::Cash from our documentation (sender_city_of_birth, country_of_birth). We did the change in this ticket but we haven't updated the API docs https://azafinance.atlassian.net/browse/BTA-5316