### PR TITLE
BTA-7084 Update API documentation with recipient type

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -21,10 +21,10 @@
     - kyc
     - transaction-flow
     - error-handling
-    - payout-details
+    - individual-payments
+    - business-payments
     - additional-features
     - collection-details
-    - business-transactions
     - sandbox-testing
     - reports-api
     - changelog

--- a/_docs/business-payments.md
+++ b/_docs/business-payments.md
@@ -1,12 +1,16 @@
 ---
-title: Business transactions
-permalink: /docs/business-transactions/
+title: Business payments
+permalink: /docs/business-payments/
 ---
 
 * Table of contents
 {:toc}
 
-# Business transactions
+This document lists the required details that needs to be sent for each of our payout corridor
+
+<div class="alert alert-info" markdown="1">
+**Note** Occasionally there might be issues with one of the corridors and we might have to disable them temporarily. Once youre onboarded we'll let you know if this happens. Also if you're trying to use a disabled corridor you're going to receive a validation error stating that the corridor is not active, and you won't be able to create new transactions there.
+</div>
 
 Our system not only allows transactions from personal senders to personal recipients, but also to and from business senders and business recipients. Note however that regulatory and other requirements might be more strict for these transactions, so before you start implementing business transactions please reach out to our sales and account management team for more information.
 
@@ -14,7 +18,7 @@ Our system not only allows transactions from personal senders to personal recipi
 **Warning!** Business transactions are not available to/from all of our corridors. Make sure you reach out to our team to know what is allowed before proceeding with the implementation!
 </div>
 
-## Business senders
+# Business senders
 
 For business senders you need to provide different details than for personal senders. More specifically you need to provide:
 
@@ -231,7 +235,7 @@ sender.setAddressDescription("");
 
 // Company Details
 sender.setLegalEntityType(LegalEntityTypeEnum.PRIVATELY_OWNED_COMPANY);
-sender.setRegistrationDate(LocalDate.parse(2012-01-25"));
+sender.setRegistrationDate(LocalDate.parse("2012-01-25"));
 sender.setRegistrationNumber("VAT1234567");
 sender.setNatureOfBusiness(NatureOfBusinessEnum.RETAIL_TRADE);
 
@@ -339,7 +343,7 @@ sender.address_description = ""
 
 # Company Details
 sender.legal_entity_type = "privately_owned_company"
-sender.registration_date = 2012-01-25"
+sender.registration_date = "2012-01-25"
 sender.registration_number = "VAT1234567"
 sender.nature_of_business = "retail_trade"
 
@@ -364,7 +368,6 @@ The valid values for the company type / legal entity type are the following:
 
 {% capture data-raw %}
 ```markdown
-- sole_proprietorship: Sole Proprietorship
 - partnership: Partnership
 - privately_owned_company: Privately Owned Company (Limited Company)
 - publicly_owned_company: Publicly Listed Company (PLC)
@@ -387,6 +390,278 @@ The valid values for the industry / nature of business are the following:
 
 {% capture data-raw %}
 ```markdown
+- personal: Personal
+- agriculture_and_hunting: Agriculture and Hunting
+- forestry: Forestry
+- fishing: Fishing
+- agricultural_by_products: Agricultural By-Products
+- coal_mining: Coal Mining
+- oil_mining: Oil Mining
+- iron_ore_mining: Iron Ore Mining
+- other_metal_and_diamond_mining: Other Metal and Diamond Mining
+- other_mineral_mining: Other Mineral Mining
+- manufacturing_of_food_drink_tobacco: Manufacture of Food/Drink/Tobacco
+- manufacturing_of_textiles_leather_fur_furniture: Manufacture of Textiles/Leather/Fur/Furniture
+- manufacture_of_wooden_products_furniture: Manufacture of Wooden Products/Furniture
+- manufacture_of_paper_pulp_allied_products: Manufacture of Paper/Pulp/Allied Products
+- manufacture_of_chemicals_medical_petroleum_rubber_plastic_products: Manufacture Of Chemicals Medical Petroleum Rubber Plastic Products
+- manufacture_of_pottery_china_glass_stone: Manufacture Of Pottery China Glass Stone
+- manufacture_of_iron_steel_non_ferrous_metals_basic_industries: Manufacture Of Iron Steel Non-Ferrous Metals Basic Industries
+- manufacture_of_metal_products_electrical_and_scientific_engineering: Manufacture Of Metal Products Electrical And Scientific Engineering
+- manufacture_of_jewelry_musical_instruments_toys: Manufacture Of Jewelry Musical Instruments Toys
+- electricity_gas_and_water: Electricity, Gas And Water
+- construction: Construction
+- wholesale_trade: Wholesale Trade
+- retail_trade: Retail Trade
+- catering_incl_hotels: Catering Incl. Hotels
+- transport_storage: Transport Storage
+- communications: Communications
+- finance_and_holding_companies: Finance And Holding Companies
+- insurance: Insurance
+- business_services: Business Services
+- real_estate_development_investment: Real Estate Development Investment
+- central_state_governments: Central State Governments
+- community_services_defence_police_prisons_etc: Community Services Defence Police Prisons Etc
+- social_services_education_health_care: Social Services Education Health Care
+- personal_services_leisure_services: Personal Services - Leisure Services
+- personal_services_domestic_laundry_repairs: Personal Services - Domestic Laundry Repairs
+- personal_services_embassies_international_organisations: Personal Services - Embassies
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="nature-of-business-details" raw=data-raw %}
+
+# Business recipients
+
+## Ghana
+
+### GHS::Bank
+
+For Ghanan bank payments please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "name": "Company name",
+  "bank_code": "030100",
+  "bank_account": "123456789"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="ghs-bank-details" raw=data-raw %}
+
+The current banks supported and their `bank_codes` values are:
+
+{% capture data-raw %}
+```
+ABSA Ghana Bank (formerly Barclays): 030100
+Access Bank: 280100
+Agricultural Development Bank: 080100
+Bank of Africa: 210100
+CAL Bank: 140100
+Ecobank: 130100
+Fidelity Bank: 240100
+First Atlantic Bank: 170100
+First Bank Nigeria: 200100
+First National Bank: 330100
+GCB Bank: 040100
+Guaranty Trust Bank: 230100
+Heritage Bank: 370100
+National Investment Bank: 050100
+Prudential Bank: 180100
+Republic HFC Bank: 110100
+Stanbic Bank: 190100
+Standard Chartered Bank: 020100
+United Bank for Africa: 060100
+Zenith Bank: 120100
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="ghs-bank-options" raw=data-raw %}
+
+Please note that there is no standard format across banks for account numbers in this corridor. If you wish to check for correctness you can see the following list:
+
+{% capture data-raw %}
+```
+ABSA Ghana Bank (formerly Barclays): 10 or 13 digits
+Access Bank: 13 digits
+Agricultural Development Bank: 16 digits
+Bank of Africa: 11 digits
+CAL Bank: 13 digits
+Ecobank: 13 or 16 digits
+Fidelity Bank: 13 digits
+First Atlantic Bank: 13 digits
+First Bank Nigeria: 13 digits
+First National Bank: 11 digits
+GCB Bank: 13 digits
+Guaranty Trust Bank: 13 digits
+Heritage Bank: 13 digits
+National Investment Bank: 13 digits
+Prudential Bank: 13 digits
+Republic HFC Bank: 13 digits
+Stanbic Bank: 13 digits
+Standard Chartered Bank: 13 digits
+United Bank for Africa: 13 or 14 digits
+Zenith Bank: 10 digits
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="ghs-bank-digits" raw=data-raw %}
+
+## Europe / SEPA
+
+### EUR::Bank
+
+For EUR IBAN transfers please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "name": "Company name",
+  "iban": "DE89370400440532013000",
+  "bank_name": "Deutsche Bank", // Optional
+  "bic": "DEUTDEBBXXX" // Optional
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="eur-bank-details" raw=data-raw %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning!** If the recipient account is not an `EUR` account then the recipient's bank might charge for converting the received funds from `EUR` to the local currency.
+</div>
+
+<div class="alert alert-info" markdown="1">
+**Note!** Transfer is done using the fastest method available on the recipient's bank.
+
+* If the recipient's bank supports the Instant Payment network funds will arrive within 2 hours (but usually within a couple minutes)
+* If the recipient's bank supports the SEPA system, funds will arrive within 1-2 business days
+* If the recipient's bank only supports the Swift system, funds will arrive within 2-5 business days
+</div>
+
+### GBP::Bank
+
+For GBP::Bank there are two payout options available:
+
+1. GBP Payments with account number and sort code
+2. GBP IBAN transfers
+
+For GBP Payments with account number and sort code please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "name": "Company name",
+  "bank_name": "Lloyds Bank",
+  "bank_account": "12345678",
+  "sort_code": "123456"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="gbp-bank-details" raw=data-raw %}
+
+For GBP IBAN transfers please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "name": "Company name",
+  "bank_name": "Lloyds Bank",
+  "iban": "GB29LOYD60161331926819",
+  "bic": "LOYDGB2L" // Optional
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="gbp-bank-iban-details" raw=data-raw %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning!** If the recipient account is not an `GBP` account then the recipient's bank might charge for converting the received funds from `GBP` to the local currency.
+</div>
+
+<div class="alert alert-info" markdown="1">
+**Note!**
+
+* The customer needs to enter either an IBAN (and an optional BIC), or an account number and sort code.
+* Transfer is done using the fastest method available on the recipient's bank.
+* If the recipient's bank is in the UK, and supports the Faster Payment network funds will arrive within 2 hours (but usually within a couple minutes)
+* If the recipient's bank supports the SEPA system, funds will arrive within 1-2 business days
+* If the recipient's bank only supports the Swift system, funds will arrive within 2-5 business days
+</div>
+
+## West Africa / XOF
+
+### XOF::Bank
+
+For West African bank payments in selected countries please use the following:
+
+{% capture data-raw %}
+```javascript
+"details" : {
+  "name": "Company name",
+  "iban": "BJ0610100100144390000769", // BBAN format: AA123 12345 123456789012 12
+  "bank_name": "Bank Of Africa Bénin" // optional
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xof-bank-details" raw=data-raw %}
+
+<div class="alert alert-info" markdown="1">
+**Note** `XOF::Bank` payouts are currently in beta phase.
+</div>
+
+## South Africa
+
+### ZAR::Bank
+
+For South African bank payments please use the following recipient details.
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "name": "Company name",
+  "street": "14 Main Street", // should include house number as well
+  "postal_code": "AB0001",
+  "city": "Cape Town",
+  "email": "recipient@email.com", // optional, but highly recommended
+  "bank_code": "334810",
+  "bank_account": "12345678",
+  "phone_number": "+27119785313",
+  "contact_first_name": "First",
+  "contact_last_name": "Last",
+  "transfer_reason_code": "185",
+  "legal_entity_type": "privately_owned_company",
+  "registration_number": "VAT1234567", // optional
+  "nature_of_business": "retail_trade" // optional
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="zar-bank-details-business" raw=data-raw %}
+
+The company types supported and corresponding `legal_entity_type` are:
+
+{% capture data-raw %}
+```
+Sole Proprietorship: sole_proprietorship
+Partnership: partnership
+Privately Owned Company (Limited Company): privately_owned_company
+Publicly Listed Company (PLC): publicly_owned_company
+Government Owned Entity Trusts: government_owned_entity
+GO (Majority Owned Subsidiary of State-Owned Company): go
+Financial Institution: financial_institution
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="zar-entity-types" raw=data-raw %}
+
+The valid values for `nature_of_business` are the following:
+
+{% capture data-raw %}
+```
 - Personal: personal
 - Agriculture and Hunting: agriculture_and_hunting
 - Forestry: forestry
@@ -426,8 +701,57 @@ The valid values for the industry / nature of business are the following:
 ```
 {% endcapture %}
 
-{% include language-tabbar.html prefix="nature-of-business-details" raw=data-raw %}
+{% include language-tabbar.html prefix="zar-nature-of-business" raw=data-raw %}
 
-## Business recipients
+List of transfer reasons and corresponding `transfer_reason_code` are:
 
-For business recipients the only change you have to make is use of the `name` value instead of `first_name` and `last_name`. Please see our [payout details documentation]({{ "/docs/payout-details/" | prepend: site.baseurl }}) on how to specify the rest of the details for each of our payout corridors.
+{% capture data-raw %}
+```
+Sending money into my own account: 183
+Donations and gifts: 184
+Sending money to a friend, family member or any third party person: 185
+Mortgage repayments: 186
+Business Travel Payments: 187
+Personal Travel Payments: 188
+Tuition fees: 189
+Investment into property by a foreign individual: 192
+Investment by a foreign individual - other: 193
+Legal services: 196
+Accounting services: 197
+Management consulting services: 198
+Advertising & market research services: 200
+Managerial services: 201
+Cultural and recreational services: 205
+Salary paid to South African Resident Temporarily Abroad: 206
+Salary paid to a non-resident employee in South Africa: 207
+Salary paid to a foreign national contract worker in South Africa: 208
+Pensions: 213
+Annuities: 214
+Inheritances: 215
+Alimony: 216
+Tax - Income tax: 217
+Tax - VAT refunds: 218
+Tax - Other: 219
+Dividends: 222
+Commission or brokerage: 224
+Rental: 225
+Income earned abroad by a resident on an individual investment: 226
+Architectural, engineering and other technical services: 245
+Payments for data, news related and news agency fees: 249
+Computer-related services including maintenance, repair and consultancy: 279
+Proceeds for other business services not included elsewhere: 309
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="zar-transfer-reason-codes" raw=data-raw %}
+
+Please note that due to regulatory reasons senders trying to create `ZAR::Bank` transactions are required to have the following fields on the sender present as well:
+`street`, `city` and `postal_code`
+
+<div class="alert alert-info" markdown="1">
+**Note** To accept payments in South Africa the recipient has to sign a mandate form online. The link to the form will be sent over the recipient's mobile phone number and email address, and have to be filled out online. Once the mandate is signed it is valid for one year and the recipient doesn't need to do these steps again. When sending funds to the same recipient please make sure their name and bank details are the same, otherwise they might be asked to sign the mandate form again.
+</div>
+
+<div class="alert alert-warning" markdown="1">
+**Warning** `ZAR::Bank` payouts are currently in beta phase.
+</div>

--- a/_docs/business-payments.md
+++ b/_docs/business-payments.md
@@ -199,7 +199,7 @@ Dim sender as Sender = New Sender(
 
 ' Company Details
   legalEntityType:=LegalEntityTypeEnum.PRIVATELY_OWNED_COMPANY,
-  registrationDate:=DateTime.Parse(2012-01-25"),
+  registrationDate:=DateTime.Parse("2012-01-25"),
   registrationNumber:="VAT1234567",
   natureOfBusiness:=NatureOfBusinessEnum.RETAIL_TRADE,
 
@@ -271,7 +271,7 @@ sender.address_description = "";
 
 // Company Details
 sender.legal_entity_type = "privately_owned_company";
-sender.registration_date = 2012-01-25";
+sender.registration_date = "2012-01-25";
 sender.registration_number = "VAT1234567";
 sender.nature_of_business = "retail_trade";
 
@@ -368,6 +368,7 @@ The valid values for the company type / legal entity type are the following:
 
 {% capture data-raw %}
 ```markdown
+- sole_proprietorship: Sole Proprietorship
 - partnership: Partnership
 - privately_owned_company: Privately Owned Company (Limited Company)
 - publicly_owned_company: Publicly Listed Company (PLC)

--- a/_docs/crypto.md
+++ b/_docs/crypto.md
@@ -6,11 +6,11 @@ permalink: /docs/crypto-transactions/
 * Table of contents
 {:toc}
 
-Our system also supports transactions involving BTC. You can either use the system to send or to receive BTC. These features are very similar to our [payout]({{ "/docs/payout-details/" | prepend: site.baseurl }}) and [collection]({{ "/docs/collection-details/" | prepend: site.baseurl }}) system. Before using our crypto platform please familiarize yourself with how fiat transactions work in our system.
+Our system also supports transactions involving BTC. You can either use the system to send or to receive BTC. These features are very similar to our [payout]({{ "/docs/individual-payments/" | prepend: site.baseurl }}) and [collection]({{ "/docs/collection-details/" | prepend: site.baseurl }}) system. Before using our crypto platform please familiarize yourself with how fiat transactions work in our system.
 
 # Sending BTC
 
-Please read our [transaction flow]({{ "/docs/transaction-flow/" | prepend: site.baseurl }}) and [payout documentation]({{ "/docs/payout-details/" | prepend: site.baseurl }}) for more information on how payments work.
+Please read our [transaction flow]({{ "/docs/transaction-flow/" | prepend: site.baseurl }}) and [payout documentation]({{ "/docs/individual-payments/" | prepend: site.baseurl }}) for more information on how payments work.
 
 To send BTC to a wallet you'll have to use the following payout details:
 
@@ -78,7 +78,7 @@ The `Address` field contains the BTC address where the funds have to be sent, an
 
 Once the customer sends in the funds then dependent on the amount and the current state of the BTC system we will wait for a certain amount of confirmations before we consider the transaction paid.
 
-Funds collected from BTC can either go to an internal fiat balance (e.g. `USD::Balance` or `NGN::Balance`) or can be used immediately to pay out a recipient as stated in the [payout documentation]({{ "/docs/payout-details/" | prepend: site.baseurl }})
+Funds collected from BTC can either go to an internal fiat balance (e.g. `USD::Balance` or `NGN::Balance`) or can be used immediately to pay out a recipient as stated in the [payout documentation]({{ "/docs/individual-payments/" | prepend: site.baseurl }})
 
 <div class="alert alert-warning" markdown="1">
 **Warning!** Due to the volatility of BTC, the exchange rates might have changed in case the funds are first routed to an internal balance and only then used to pay out a recipient.

--- a/_docs/example-payments.md
+++ b/_docs/example-payments.md
@@ -377,7 +377,7 @@ sender.documents = []
 
 # Recipient details
 
-Once you have the sender let's set up the recipient as well. In this example we're going to do an `NGN::Bank` payout, which requires a name and the bank account details. Other payout providers might have different requirements, to check them please see our [payout details documentation]({{ "/docs/payout-details/" | prepend: site.baseurl }}). You'll also need to send in how much you wish to send. In this example we're sending $100 worth of funds, that are going to be received in NGN - we'll calculate the proper amount based on the exchange rates.
+Once you have the sender let's set up the recipient as well. In this example we're going to do an `NGN::Bank` payout, which requires a name and the bank account details. Other payout providers might have different requirements, to check them please see our [individual payments documentation]({{ "/docs/individual-payments/" | prepend: site.baseurl }}). You'll also need to send in how much you wish to send. In this example we're sending $100 worth of funds, that are going to be received in NGN - we'll calculate the proper amount based on the exchange rates.
 
 {::comment}
 CODE_EXAMPLE_START recipient-creation
@@ -385,6 +385,7 @@ JSON_START
 {
     "requested_amount": "100",
     "requested_currency": "USD",
+    "type": "person",
     "payout_method": {
         "type": "NGN::Bank",
         "details": {
@@ -415,6 +416,7 @@ CREATE_END
 CREATE_START recipient Recipient
 SET BIGNUM requested_amount 100000
 SET LIT requested_currency "NGN"
+SET LIT type "person"
 SET VAR payout_method payout
 CREATE_END
 CODE_END
@@ -427,6 +429,7 @@ CODE_EXAMPLE_END
 {
     "requested_amount": "100",
     "requested_currency": "USD",
+    "type": "person",
     "payout_method": {
         "type": "NGN::Bank",
         "details": {
@@ -457,6 +460,7 @@ PayoutMethod payout = new PayoutMethod(
 Recipient recipient = new Recipient(
   requestedAmount: 100000,
   requestedCurrency: "NGN",
+  type: "person",
   payoutMethod: payout);
 ```
 {% endcapture %}
@@ -477,6 +481,7 @@ Dim payout as PayoutMethod = New PayoutMethod(
 Dim recipient as Recipient = New Recipient(
   requestedAmount:=100000,
   requestedCurrency:="NGN",
+  type:="person",
   payoutMethod:=payout)
 ```
 {% endcapture %}
@@ -497,6 +502,7 @@ payout.setDetails(details);
 Recipient recipient = new Recipient();
 recipient.setRequestedAmount(new BigDecimal("100000"));
 recipient.setRequestedCurrency("NGN");
+recipient.setType("person");
 recipient.setPayoutMethod(payout);
 ```
 {% endcapture %}
@@ -517,6 +523,7 @@ payout.details = details;
 const recipient = new TransferZeroSdk.Recipient();
 recipient.requested_amount = 100000;
 recipient.requested_currency = "NGN";
+recipient.type = "person";
 recipient.payout_method = payout;
 ```
 {% endcapture %}
@@ -537,6 +544,7 @@ $payout->setDetails($details);
 $recipient = new Recipient();
 $recipient->setRequestedAmount(100000);
 $recipient->setRequestedCurrency("NGN");
+$recipient->setType("person");
 $recipient->setPayoutMethod($payout);
 ```
 {% endcapture %}
@@ -557,6 +565,7 @@ payout.details = details
 recipient = TransferZero::Recipient.new
 recipient.requested_amount = 100000
 recipient.requested_currency = "NGN"
+recipient.type = "person"
 recipient.payout_method = payout
 ```
 {% endcapture %}

--- a/_docs/example-payments.md
+++ b/_docs/example-payments.md
@@ -502,7 +502,7 @@ payout.setDetails(details);
 Recipient recipient = new Recipient();
 recipient.setRequestedAmount(new BigDecimal("100000"));
 recipient.setRequestedCurrency("NGN");
-recipient.setType("person");
+recipient.setType(Recipient.TypeEnum.fromValue("person"));
 recipient.setPayoutMethod(payout);
 ```
 {% endcapture %}

--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -1,6 +1,6 @@
 ---
-title: Payout details
-permalink: /docs/payout-details/
+title: Individual payments
+permalink: /docs/individual-payments/
 ---
 
 * Table of contents
@@ -593,27 +593,11 @@ orange
 
 For West African bank payments in selected countries please use the following:
 
-Personal recipient:
-
 {% capture data-raw %}
 ```javascript
 "details" : {
   "first_name": "First",
   "last_name": "Last",
-  "iban": "BJ0610100100144390000769", // BBAN format: AA123 12345 123456789012 12
-  "bank_name": "Bank Of Africa Bénin" // optional
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="xof-bank-details" raw=data-raw %}
-
-Business recipient:
-
-{% capture data-raw %}
-```javascript
-"details" : {
-  "name": "Company name",
   "iban": "BJ0610100100144390000769", // BBAN format: AA123 12345 123456789012 12
   "bank_name": "Bank Of Africa Bénin" // optional
 }
@@ -631,8 +615,6 @@ Business recipient:
 ## ZAR::Bank
 
 For South African bank payments please use the following recipient details.
-
-Personal recipient:
 
 {% capture data-raw %}
 ```javascript
@@ -652,92 +634,6 @@ Personal recipient:
 {% endcapture %}
 
 {% include language-tabbar.html prefix="zar-bank-details-personal" raw=data-raw %}
-
-Business recipient:
-
-{% capture data-raw %}
-```javascript
-"details": {
-  "name": "Company name",
-  "street": "14 Main Street", // should include house number as well
-  "postal_code": "AB0001",
-  "city": "Cape Town",
-  "email": "recipient@email.com", // optional, but highly recommended
-  "bank_code": "334810",
-  "bank_account": "12345678",
-  "phone_number": "+27119785313",
-  "contact_first_name": "First",
-  "contact_last_name": "Last",
-  "transfer_reason_code": "185",
-  "legal_entity_type": "privately_owned_company",
-  "registration_number": "VAT1234567", // optional
-  "nature_of_business": "retail_trade" // optional
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="zar-bank-details-business" raw=data-raw %}
-
-The company types supported and corresponding `legal_entity_type` are:
-
-{% capture data-raw %}
-```
-Sole Proprietorship: sole_proprietorship
-Partnership: partnership
-Privately Owned Company (Limited Company): privately_owned_company
-Publicly Listed Company (PLC): publicly_owned_company
-Government Owned Entity Trusts: government_owned_entity
-GO (Majority Owned Subsidiary of State-Owned Company): go
-Financial Institution: financial_institution
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="zar-entity-types" raw=data-raw %}
-
-The valid values for `nature_of_business` are the following:
-
-{% capture data-raw %}
-```
-- Personal: personal
-- Agriculture and Hunting: agriculture_and_hunting
-- Forestry: forestry
-- Fishing: fishing
-- Agricultural By-Products: agricultural_by_products
-- Coal Mining: coal_mining
-- Oil Mining: oil_mining
-- Iron Ore Mining: iron_ore_mining
-- Other Metal and Diamond Mining: other_metal_and_diamond_mining
-- Other Mineral Mining: other_mineral_mining
-- Manufacture of Food/Drink/Tobacco: manufacturing_of_food_drink_tobacco
-- Manufacture of Textiles/Leather/Fur/Furniture: manufacturing_of_textiles_leather_fur_furniture
-- Manufacture of Wooden Products/Furniture: manufacture_of_wooden_products_furniture
-- Manufacture of Paper/Pulp/Allied Products: manufacture_of_paper_pulp_allied_products
-- Manufacture Of Chemicals Medical Petroleum Rubber Plastic Products: manufacture_of_chemicals_medical_petroleum_rubber_plastic_products
-- Manufacture Of Pottery China Glass Stone: manufacture_of_pottery_china_glass_stone
-- Manufacture Of Iron Steel Non-Ferrous Metals Basic Industries: manufacture_of_iron_steel_non_ferrous_metals_basic_industries
-- Manufacture Of Metal Products Electrical And Scientific Engineering: manufacture_of_metal_products_electrical_and_scientific_engineering
-- Manufacture Of Jewelry Musical Instruments Toys: manufacture_of_jewelry_musical_instruments_toys
-- Electricity, Gas And Water: electricity_gas_and_water
-- Construction: construction
-- Wholesale Trade: wholesale_trade
-- Retail Trade: retail_trade
-- Catering Incl. Hotels: catering_incl_hotels
-- Transport Storage: transport_storage
-- Communications: communications
-- Finance And Holding Companies: finance_and_holding_companies
-- Insurance: insurance
-- Business Services: business_services
-- Real Estate Development Investment: real_estate_development_investment
-- Central State Governments: central_state_governments
-- Community Services Defence Police Prisons Etc: community_services_defence_police_prisons_etc
-- Social Services Education Health Care: social_services_education_health_care
-- Personal Services - Leisure Services: personal_services_leisure_services
-- Personal Services - Domestic Laundry Repairs: personal_services_domestic_laundry_repairs
-- Personal Services - Embassies: personal_services_embassies_international_organisations
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="zar-nature-of-business" raw=data-raw %}
 
 List of transfer reasons and corresponding `transfer_reason_code` are:
 

--- a/_docs/transaction-flow.md
+++ b/_docs/transaction-flow.md
@@ -43,6 +43,7 @@ Transactions can be created by calling the `POST /v1/transactions` endpoint. The
          {
             "requested_amount": // the amount to pay out,
             "requested_currency": // the currency of the amount,
+            "type": "person", // the type of the recipient, either person or business
             "payout_method":{
                "type": // method of the payout,
                "details":{
@@ -90,6 +91,7 @@ JSON_START
       {
         "requested_amount": "100",
         "requested_currency": "USD",
+        "type": "person",
         "payout_method": {
           "type": "NGN::Bank",
           "details": {
@@ -143,6 +145,7 @@ CREATE_END
 CREATE_START recipient Recipient
 SET BIGNUM requested_amount 100000
 SET LIT requested_currency "NGN"
+SET LIT type "person"
 SET VAR payout_method payout
 CREATE_END
 
@@ -182,6 +185,7 @@ CODE_EXAMPLE_END
       {
         "requested_amount": "100",
         "requested_currency": "USD",
+        "type": "person",
         "payout_method": {
           "type": "NGN::Bank",
           "details": {
@@ -234,6 +238,7 @@ PayoutMethod payout = new PayoutMethod(
 Recipient recipient = new Recipient(
   requestedAmount: 100000,
   requestedCurrency: "NGN",
+  type: "person",
   payoutMethod: payout);
 
 Transaction transaction = new Transaction(
@@ -276,6 +281,7 @@ Dim payout as PayoutMethod = New PayoutMethod(
 Dim recipient as Recipient = New Recipient(
   requestedAmount:=100000,
   requestedCurrency:="NGN",
+  type:="person",
   payoutMethod:=payout)
 
 Dim transaction as Transaction = New Transaction(
@@ -318,6 +324,7 @@ payout.setDetails(details);
 Recipient recipient = new Recipient();
 recipient.setRequestedAmount(new BigDecimal("100000"));
 recipient.setRequestedCurrency("NGN");
+recipient.setType("person");
 recipient.setPayoutMethod(payout);
 
 Transaction transaction = new Transaction();
@@ -360,6 +367,7 @@ payout.details = details;
 const recipient = new TransferZeroSdk.Recipient();
 recipient.requested_amount = 100000;
 recipient.requested_currency = "NGN";
+recipient.type = "person";
 recipient.payout_method = payout;
 
 const transaction = new TransferZeroSdk.Transaction();
@@ -402,6 +410,7 @@ $payout->setDetails($details);
 $recipient = new Recipient();
 $recipient->setRequestedAmount(100000);
 $recipient->setRequestedCurrency("NGN");
+$recipient->setType("person");
 $recipient->setPayoutMethod($payout);
 
 $transaction = new Transaction();
@@ -444,6 +453,7 @@ payout.details = details
 recipient = TransferZero::Recipient.new
 recipient.requested_amount = 100000
 recipient.requested_currency = "NGN"
+recipient.type = "person"
 recipient.payout_method = payout
 
 transaction = TransferZero::Transaction.new
@@ -873,6 +883,7 @@ The template for the recipient is the following:
 {
   "requested_amount": // the amount to pay out,
   "requested_currency": // the currency of the amount,
+  "type": // the type of the recipient, either person or business
   "payout_method":{
       "type": // method of the payout,
       "details":{
@@ -885,11 +896,13 @@ The template for the recipient is the following:
 
 {% include language-tabbar.html prefix="recipient-structure" raw=data-raw %}
 
+### Recipient type
+
 ### Payout type
 
 The payout type contains where the money should be sent to and to what currency. You can find a complete list of supported types at the [API reference documentation](https://api.transferzero.com/documentation#transactions).
 
-You can find the commonly used payout types at the [payout documentation]({{ "/docs/payout-details/" | prepend: site.baseurl }}).
+You can find the commonly used payout types at the [payout documentation]({{ "/docs/individual-payments/" | prepend: site.baseurl }}).
 
 Unless you hold an internal balance with us, the input currency and payout currency cannot be the same. If you wish to do same-currency transactions please contact our team for further details.
 
@@ -929,7 +942,7 @@ The current list of currencies and associated decimal places is below -
 
 ### Payout details
 
-The payout details depend on the chosen payout type. Please check the [Payout documentation]({{ "/docs/payout-details/" | prepend: site.baseurl }}) for more details, and you can also find example calls at the [API reference documentation](https://api.transferzero.com/documentation#transactions).
+The payout details depend on the chosen payout type. Please check the [Payout documentation]({{ "/docs/individual-payments/" | prepend: site.baseurl }}) for more details, and you can also find example calls at the [API reference documentation](https://api.transferzero.com/documentation#transactions).
 
 ## Metadata
 
@@ -992,6 +1005,7 @@ A transaction object looks like the following:
     "recipients": [
       {
         "id": "31288256-ec72-4a0a-bab7-06fb3a6cc8dd",
+        "type": "person",
         "transaction_id": "5280d11f-0ed3-4a60-ab07-29fdb058e4c4",
         "created_at": "2017-08-08T13:19:32.855Z",
         "input_usd_amount": 772.5,

--- a/_docs/transaction-flow.md
+++ b/_docs/transaction-flow.md
@@ -755,7 +755,7 @@ When a sender is created you will receive a response which contains the sender's
 
 In order to transact with TransferZero we need to have an `approved` sender record. The flow for approving senders depend on whether KYC requirements are waived for your integration or not. In case the KYC requirements are waived then all created senders will be in the `approved` state immediately, and can be immediately used for transactions.
 
-Please see our [KYC](({{ "/docs/kyc/" | prepend: site.baseurl }})) documentation on more details about the KYC sender processes.
+Please see our [KYC documentation]({{ "/docs/kyc/" | prepend: site.baseurl }}) on more details about the KYC sender processes.
 
 ### ID and External ID
 
@@ -771,6 +771,13 @@ An exception to this is if the `external_id` is provided along with additional f
 Please note that sending both an `id` and `external_id` at once is invalid and will result in an error.
 
 If a sender has been assigned an `external_id`, this value can be used to find senders using the `GET /v1/senders` endpoint, with `external_id` parameter included as a string. For example: `GET /v1/senders?external_id=76f69f5e`
+
+### Sender type
+The sender type indicates if the sender is a person or business.
+
+Please note the sender details vary depending on the sender typology.
+
+Please refer to the [example above]({{ "#sender" | prepend: site.baseurl }}) (for personal senders) and to [Business payments]({{ "/docs/business-payments/#business-senders" | prepend: site.baseurl }}) (for business senders) for more details.
 
 ### Metadata
 
@@ -897,6 +904,14 @@ The template for the recipient is the following:
 {% include language-tabbar.html prefix="recipient-structure" raw=data-raw %}
 
 ### Recipient type
+
+The recipient type indicates if the recipient is a person or business.
+
+Please note the payout details vary depending on the recipient typology.
+
+The `name` field is mandatory for business recipients.
+
+Please refer to the [Individual payments]({{ "/docs/individual-payments" | prepend: site.baseurl }}) and [Business payments]({{ "/docs/business-payments" | prepend: site.baseurl }}) sections for more details.
 
 ### Payout type
 

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -17,7 +17,8 @@
                 <li><a href="{{ "/docs/example-payments/" | prepend: site.baseurl }}">Examples</a></li>
                 <li><a href="{{ "/docs/sdks/" | prepend: site.baseurl }}">SDKs</a></li>
                 <li><a href="{{ "/docs/architecture/" | prepend: site.baseurl }}">Architecture</a></li>
-                <li><a href="{{ "/docs/payout-details/" | prepend: site.baseurl }}">Payments</a></li>
+                <li><a href="{{ "/docs/individual-payments/" | prepend: site.baseurl }}">Individual payments</a></li>
+                <li><a href="{{ "/docs/business-payments/" | prepend: site.baseurl }}">Business payments</a></li>
                 <li><a href="{{ "/docs/collection-details/" | prepend: site.baseurl }}">Collections</a></li>
                 <li><a href="{{ "/docs/reference-documentation/" | prepend: site.baseurl }}">Reference</a></li>
             </ul>

--- a/_sass/bootswatch/yeti/_variables.scss
+++ b/_sass/bootswatch/yeti/_variables.scss
@@ -348,7 +348,7 @@ $container-desktop:            (940px + $grid-gutter-width) !default;
 $container-md:                 $container-desktop !default;
 
 // Large screen / wide desktop
-$container-large-desktop:      (1140px + $grid-gutter-width) !default;
+$container-large-desktop:      (1305px + $grid-gutter-width) !default;
 //** For `$screen-lg-min` and up.
 $container-lg:                 $container-large-desktop !default;
 


### PR DESCRIPTION
[BTA-7084](https://azafinance.atlassian.net/browse/BTA-7084): Update API documentation with recipient type

Changes
---------

- Renamed payout details to individual payments.
- Renamed business transactions to business payments.
- Added Sender type and Recipient type sections to the transaction flow.
- Added recipient type to payments example.
- Moved business recipients details from individual payments (former payout details) to business payments (former business transactions).

![Screenshot 2021-09-16 at 16 01 56](https://user-images.githubusercontent.com/40522592/133636895-1badf2b3-e298-46a1-87c0-ff86d57c1bbd.png)

![Screenshot 2021-09-16 at 16 01 36](https://user-images.githubusercontent.com/40522592/133636891-d974aae2-4a52-4831-b1ad-b1d9dc581ed1.png)

![Screenshot 2021-09-16 at 16 02 18](https://user-images.githubusercontent.com/40522592/133636898-6d90b185-290d-4f61-969a-e9fdef389080.png)

![Screenshot 2021-09-16 at 16 02 34](https://user-images.githubusercontent.com/40522592/133636900-826b0452-52d1-4069-a94d-f4741d79b350.png)

![Screenshot 2021-09-16 at 16 07 01](https://user-images.githubusercontent.com/40522592/133637318-3b4eedf9-af5a-41ee-8e07-ee68bd51dfd1.png)

![Screenshot 2021-09-16 at 16 07 12](https://user-images.githubusercontent.com/40522592/133637321-5afa5e85-deb5-46d1-b3e0-9a8f675ae30c.png)
