### PR TITLE
BTA-7328 Change ID type recipient

### DIFF
--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -461,7 +461,7 @@ For Kenyan bank payments please use:
   "branch_code": "404",
   "bank_account": "12345678",
   "swift_code": "EQBLKENA",
-  "identity_card_type": "NI", // refers to the recipient's ID details; Values: "PP": Passport, "NI": National ID
+  "identity_card_type": "ID", // refers to the recipient's ID details; Values: "PP": Passport, "ID": National ID or "O": Other
   "identity_card_id": 'AB12345678', // refers to the recipient's ID details
   "transfer_reason": "third_party_person_account"
 }
@@ -561,7 +561,7 @@ For Kenyan mobile payments please use:
   "last_name": "Last",
   "street": "1 Linford Street",
   "phone_number": "254123456789", // local or international Kenyan format
-  "identity_card_type": "NI", // refers to the recipient's ID details; Values: "PP": Passport, "NI": National ID
+  "identity_card_type": "ID", // refers to the recipient's ID details; Values: "PP": Passport, "ID": National ID or "O": Other
   "identity_card_id": 'AB12345678', // refers to the recipient's ID details
   "transfer_reason": "personal_account",
   "mobile_provider": "mpesa"


### PR DESCRIPTION
Documentation id type recipient is wrong for KES::Bank and KES::Mobile. Needs to be PP, ID or O

This PR changes the documentation in line with the values accepted by API

<img width="997" alt="Screenshot 2021-10-20 at 16 57 47" src="https://user-images.githubusercontent.com/33194929/138128645-700513ed-dc97-4d5a-865d-b6e2b18a31d1.png">
<img width="1001" alt="Screenshot 2021-10-20 at 16 58 02" src="https://user-images.githubusercontent.com/33194929/138128684-a8c44088-34e7-4900-8b6a-085e4eca8995.png">


