### PR TITLE
Adding ZAR::Bank bank_codes to API docs

### DIFF
--- a/_includes/corridors/zar-bank.md
+++ b/_includes/corridors/zar-bank.md
@@ -84,6 +84,29 @@ Financial Institution: financial_institution
 ```
 {% endcapture %}
 
+The current banks supported and their `bank_code` values are:
+
+{% capture data-raw %}
+```
+Standard Bank: 051001
+First National Bank: 250655
+ABSA: 632005
+Nedbank: 198765
+Investec: 580105
+Capitec Bank: 470010
+Bank of Athens: 410506
+Bidvest Bank: 462005
+African Bank: 430000
+Mercantile Bank: 450905
+SA Post Office: 460005
+Tyme Bank: 678910
+Ubank: 431010
+Discovery Bank: 679000
+Bank Zero: 888000
+```
+{% endcapture %}
+
+
 {% if include.recipient_type == 'business' %}
   The company types supported and corresponding `legal_entity_type` are:
 


### PR DESCRIPTION
Adding bank_codes supported in ZAR::Bank corridor in API docs so it is accessible by clients