### PR TITLE
BTA-9555 Add Union Bank to USD Bank Payouts

### DIFF
--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -115,6 +115,7 @@ The valid `bank_code` values are:
 Access Bank: 044
 FCMB Bank: 214
 Fidelity Bank: 070
+Union Bank: 032
 United Bank for Africa: 033
 Zenith International: 057
 ```


### PR DESCRIPTION
Add Union Bank with bank code 032 to documentation for payouts USD::Bank
linked tickets: https://github.com/bitpesa/bitpesa-api/pull/2136 and https://github.com/bitpesa/bitpesa-utils/pull/401

![Screenshot 2022-09-22 at 10 11 29](https://user-images.githubusercontent.com/33194929/191712749-7de2304d-1046-4389-b85e-2584a273a225.png)
