### PR TITLE
BTA-9584 Update XAF region corridors format

### DIFF
--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -467,7 +467,7 @@ mobicash
 
 {% include corridors/xof-bank.md recipient_type='individual' %}
 
-# Cameroon
+# Central Africa / XAF
 
 {% include corridors/xaf-bank.md recipient_type='individual' %}
 

--- a/_includes/corridors/xaf-bank.md
+++ b/_includes/corridors/xaf-bank.md
@@ -2,7 +2,7 @@
 
 ## XAF::Bank
 
-For Cameroon bank payments please use:
+For bank payments in Central Africa please use:
 
 {% capture data-raw %}
 ```javascript
@@ -20,6 +20,7 @@ The current banks supported and their `bank_code` values are:
 
 {% capture data-raw %}
 ```
+# Cameroon
 Banque Internationale du Cameroun pour l'Epargne et le Crédit: 10001
 Societe Commerciale de Banque - Cameroun: 10002
 Société Générale de Banques au Cameroun: 10003


### PR DESCRIPTION
[BTA-9584](https://azafinance.atlassian.net/browse/BTA-9584): Update XAF region corridors format

Changes
-------

- Updates the XAF corridors, making them consistent with the West Africa / XOF region format (region/currency first, with payment methods/countries as sub-sections).

**Before:**
![Screenshot 2022-09-26 at 15 15 25](https://user-images.githubusercontent.com/40522592/192299840-663005d9-081e-4420-b556-d6f96769c683.png)

![Screenshot 2022-09-26 at 12 22 42](https://user-images.githubusercontent.com/40522592/192299195-63fdfec1-9a95-4180-9561-44e7d6da70bb.png)

**After:**
![Screenshot 2022-09-26 at 15 15 34](https://user-images.githubusercontent.com/40522592/192299846-3d756888-5aa5-47ea-88a0-cc2ecfbad355.png)

![Screenshot 2022-09-26 at 12 23 16](https://user-images.githubusercontent.com/40522592/192299201-83a40848-6e53-47ff-8f30-23ad935d94e9.png)
