### PR TITLE
Add some missing features to our main documentation

### DIFF
--- a/_docs/additional-features.md
+++ b/_docs/additional-features.md
@@ -447,3 +447,70 @@ The endpoint responds with a list of uploaded proof of payment files, e.g.:
 {% endcapture %}
 
 {% include language-tabbar.html prefix="proof-of-payments" raw=data-raw %}
+
+# Balance enquiry
+
+To obtain your current account balance you can use following two endpoints:
+
+`GET /v1/accounts` to obtain your balance for all currencies or
+
+`GET /v1/accounts/[CURRENCY_NAME]` to obtain for a single currency.
+
+The response in both cases look like the following (with only one currency returned in the latter instance)
+
+```javascript
+{
+  "meta": {
+    "negative_balance": false // returns if you are allowed to go beyond your account balance
+  },
+  "object": [
+    {
+      "amount": 1000,
+      "currency": "USD"
+    },
+    {
+      "amount": 1000,
+      "currency": "XOF"
+    }
+    // [...]
+  ]
+}
+```
+
+<div class="alert alert-warning" markdown="1">
+**Warning!** Refrain from using this endpoint more than once in every five minutes.
+</div>
+
+# Get current exchange rates
+
+To obtain the current exchange rates in the system you can call the following endpoint:
+
+`GET /v1/info/currencies/in`
+
+The response will contain all possible currency pairs. For example the current rate to convert funds from `NGN` to `XOF` will appear the following way:
+
+```javascript
+{
+  "object": [
+    {
+      "code": "NGN",
+      "opposites": [
+        {
+          "code": "XOF",
+          "rate": 1.5132,
+        },
+        // [...]
+      ]
+    },
+    // [...]
+  ]
+}
+```
+
+<div class="alert alert-warning" markdown="1">
+**Warning!** Refrain from using this endpoint more than once in every five minutes.
+</div>
+
+If you need to verify the rate before creating transactions you can use the `POST /v1/transactions/calculate` endpoint when sent a full transaction request object will return the specific rates that will be used in the response, but will not actually create the transaction.
+
+You can also separate the transaction creation and funding by using `POST /v1/transactions` and `POST /v1/accounts/debits` separately (as opposed to using `POST /v1/transactions/create_and_fund`), as this will allow you to have a transaction with the exact rates that will be used, before actually committing to posting them. Please only use this strategy if you plan on actually committing to the transactions most of the time, as all of the unfunded transactions will appear as a failed transaction on your account report.

--- a/_docs/architecture.md
+++ b/_docs/architecture.md
@@ -32,6 +32,10 @@ Please ensure that you have whitelisted the following IP addresses. The followin
 
 In case of a transmission error we will also try to send the webhook again five times before dropping the request. You'll need to reply to the endpoint call with a successful status code (e.g. `200` or `201`), otherwise we'll assume that the webhook was not delivered.
 
+<div class="alert alert-warning" markdown="1">
+**Warning!** Make sure your endpoints are reachable from the IPs mentioned above and are not timing out. Callback endpoints that don't return a HTTP response in time (even a failing one), but time out will be disabled automatically by our system after a number of retries to protect our other customers. Automatically disabled webhooks need to be recreated manually by the customer.
+</div>
+
 The structure of the body we send will always follow the following template:
 
 {% capture data-raw %}
@@ -135,3 +139,13 @@ If you have a balance with us you can use the `GET /v1/accounts` to get all or `
 If you use our API for collections, you can also use your internal balance as a wallet which would receive the funds collected from your customers.
 
 Please contact us to obtain our list of supported currency pairs for transactions.
+
+# API Limits
+
+We have soft limits around some of the endpoints that we ask customers to adhere to. These are the following:
+
+| Endpoint | Call limit / day | Notes |
+|-|-|-|
+| `GET /v1/transactions/[ID]` | 2500 | Please use the webhook/callback functionality to obtain the status of transactions. You can also find this information on your daily account report every day. Please also make sure to avoid calling the status check endpoint more often than six times in the first hour of transactions creation, and then subsequently only once every hour for each separate transaction ID you have active in our system. |
+| `GET /v1/accounts*` | 300 | Please keep track of your account balance internally in your system if you need this information more often |
+| `GET /v1/info/currencies*` | 300 | See [get current exchange rates]({{ "/docs/additional-features/#get-current-exchange-rates/" | prepend: site.baseurl }}) on alternative options you can do if you need to obtain currency information more often |


### PR DESCRIPTION
Obtaining account balance and checking for current exchange rates are very common requests, and we didn't really have these documented well apart from our specification.

Also adds a preliminary list of API limits we wish to use for status checks, balance and exchange rate enquiries, which are endpoints where customers are usually overloading our system unnecessarily.