### PR TITLE
BTA-10438 - Adds Bank Codes For Congo, CAF, Chad and Equatorial Guinea

### DIFF
--- a/_docs/business-payments.md
+++ b/_docs/business-payments.md
@@ -434,7 +434,7 @@ The valid values for the industry / nature of business are the following:
 
 {% include corridors/gbp-bank.md recipient_type='business' %}
 
-# West Africa / XOF
+# WAEMU Region / XOF
 
 {% include corridors/xof-bank.md recipient_type='business' %}
 
@@ -442,6 +442,6 @@ The valid values for the industry / nature of business are the following:
 
 {% include corridors/zar-bank.md recipient_type='business' %}
 
-# Central Africa / XAF
+# CEMAC Region / XAF
 
 {% include corridors/xaf-bank.md recipient_type='business' %}

--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -330,7 +330,7 @@ The payment reference can also be provided in the recipient details hash optiona
 **Note** For a list of Cashplus pickup points please contact us
 </div>
 
-# West Africa / XOF
+# WAEMU Region / XOF
 
 ## XOF::Cash
 
@@ -465,7 +465,7 @@ mobicash
 
 {% include corridors/xof-bank.md recipient_type='individual' %}
 
-# Central Africa / XAF
+# CEMAC Region / XAF
 
 {% include corridors/xaf-bank.md recipient_type='individual' %}
 

--- a/_includes/corridors/xaf-bank.md
+++ b/_includes/corridors/xaf-bank.md
@@ -72,6 +72,44 @@ Banque de l'Habitat du Gabon: 40023
 ECOBANK Gabon: 40024
 United Bank for Africa - Gabon: 40025
 PosteBank Gabon S.A.: 40026
+
+# Central African Republic
+ECOBANK Centrafrique: 20001
+Commercial Bank Centrafrique - CBCA: 20002
+Banque Populaire Marocco-Centrafricaine - BPMC: 20003 
+Banque Sahelo Saharienne pour l'Investissement et le Commerce Centrafrique - BSIC RCA: 20005
+
+# Congo
+Mutuelle Congolaise d'Epargne et de Crédit - MUCODEC Congo: 30005
+BGFIBank Congo: 30008
+Crédit du Congo: 30011
+LCB-BANK Congo: 30012
+Banque Commerciale Internationale - BCI Congo: 30013
+ECOBANK Congo: 30014
+Banque Congolaise de l'Habitat - BCH: 30015
+United Bank for Africa - UBA Congo: 30016
+Banque Espirito Santo Congo - BESCO: 30017
+Société Générale Congo - SGC: 30018
+Banque Postale du Congo - BPC: 30019
+Banque Sino-Congolaise pour l'Afrique - BSCA Bank: 30020
+
+# Equatorial Guinea
+CCEI Bank Guinée-Equatoriale: 50001
+Société Générale de Banques en Guinée Equatoriale - SGBE: 50002
+BGFIBANK Guinée Equatoriale: 50004
+Banco Nacional de Guinea Ecuatorial: 50005
+Ecobank Guinée Equatoriale: 50006
+
+# Chad
+ECOBANK Tchad: 60001
+Société Générale Tchad - SGT: 60002
+Commercial Bank Tchad - CBT: 60003
+Banque Commerciale du Chari - BCC Tchad: 60004
+Orabank Tchad: 60005
+Banque Agricole et Commerciale - BAC Tchad: 60006
+Banque Sahélo Saharienne pour l'Investissement et le Commerce - BSIC Tchad: 60007
+United Bank for Africa Tchad: 60008
+Banque de l'habitat du Tchad - BHT Tchad: 60009
 ```
 {% endcapture %}
 


### PR DESCRIPTION
Adds Bank Codes For Congo, CAF, Chad and Equatorial Guinea

<img width="360" alt="Screenshot 2023-01-09 at 11 55 55" src="https://user-images.githubusercontent.com/7307937/211271888-de95bf63-223b-41bb-a479-b91abc420a0d.png">
<img width="279" alt="Screenshot 2023-01-09 at 11 55 46" src="https://user-images.githubusercontent.com/7307937/211271896-b7587228-2fe6-4ab7-b899-caeb51395472.png">
<img width="745" alt="Screenshot 2023-01-09 at 11 55 39" src="https://user-images.githubusercontent.com/7307937/211271898-fad0ac67-ef40-46eb-a6e9-a5dccf1e9f8e.png">
<img width="544" alt="Screenshot 2023-01-09 at 11 55 26" src="https://user-images.githubusercontent.com/7307937/211271900-89666cbf-9265-47f1-aaaa-932c7ae5d2e5.png">

