### PR TITLE
BTA-10546 Update BRL::Bank payout method with city and postal code

### DIFF
--- a/_includes/corridors/brl-bank.md
+++ b/_includes/corridors/brl-bank.md
@@ -9,6 +9,8 @@ For Brazilian bank account payments via PIX please use:
 ```javascript
 "details" : {
   {{ recipient_name }},
+  "city": "Brasilia",
+  "postal_code": "70070",
   "phone_number": "+552112345678", // recipient phone number in international format
   "pix_key_type": "email",
   "pix_key_value": "person@example.com",
@@ -30,6 +32,8 @@ For Brazilian bank account payments using bank code and account number please us
 ```javascript
 "details" : {
   {{ recipient_name }},
+  "city": "Brasilia",
+  "postal_code": "70070",
   "phone_number": "+552112345678", // recipient phone number in international format
   "bank_code": "104",
   "branch_code": "00001",


### PR DESCRIPTION
BTA-10546: Update BRL::Bank payout method with city and postal code

Changes
-------

- Adds required fields `city` and `postal_code` to `BRL::Bank` corridor.

![Screenshot 2023-01-31 at 16 48 43](https://user-images.githubusercontent.com/40522592/216026477-d3b76580-0d4a-4589-9392-910d73859ec9.png)
