### PR TITLE
Bank code example change for a real bank code

### DIFF
--- a/_includes/corridors/zar-bank.md
+++ b/_includes/corridors/zar-bank.md
@@ -21,7 +21,7 @@ For South African bank payments please use the following recipient details:
   "postal_code": "AB0001",
   "city": "Cape Town",
   "email": "recipient@email.com", // optional, but highly recommended
-  "bank_code": "334810",
+  "bank_code": "632005",
   "bank_account": "12345678",
   "phone_number": "+27119785313", // E.164 international format
   "transfer_reason": "personal_account"{{ additional_details }}


### PR DESCRIPTION
We were using a non-listed bank code as example creating potential confusion, changed it to a listed one.