### PR TITLE
BTA-11155 Add support for orange as mobile provider for GNF::Mobile

### DIFF
--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -406,32 +406,7 @@ mtn
 
 # Guinea
 
-## GNF::Mobile
-
-For mobile payouts to Guinea, please use:
-
-{% capture data-raw %}
-```javascript
-"details": {
-  "first_name": "First",
-  "last_name": "Last",
-  "mobile_provider": "mtn", // lowercase, see provider values below
-  "phone_number": "+224444044436" // E.164 international format
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="gnf-mobile-details" raw=data-raw %}
-
-The valid `mobile_provider` values for Guinea are:
-
-{% capture data-raw %}
-```
-mtn
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="gnf-mobile-providers" raw=data-raw %}
+{% include corridors/gnf-mobile.md %}
 
 # South Africa
 

--- a/_includes/corridors/gnf-mobile.md
+++ b/_includes/corridors/gnf-mobile.md
@@ -1,0 +1,27 @@
+## GNF::Mobile
+
+For mobile payouts to Guinea, please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "first_name": "First",
+  "last_name": "Last",
+  "mobile_provider": "mtn", // lowercase, see provider values below
+  "phone_number": "+224612345678" // E.164 international format
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="gnf-mobile-details" raw=data-raw %}
+
+The valid `mobile_provider` values for Guinea are:
+
+{% capture data-raw %}
+```
+orange
+mtn
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="gnf-mobile-providers" raw=data-raw %}


### PR DESCRIPTION
Changes
---------

- Adds `orange` as available mobile provider for `GNF::Mobile` corridor.

![Screenshot 2023-05-10 at 14 28 51](https://github.com/transferzero/api-documentation/assets/40522592/598ed441-da05-49ac-b259-08868a0d6179)
