### PR TITLE
BTA-11438 Remove optional mobile provider in UGX::Mobile

### DIFF
--- a/_includes/corridors/ugx-mobile.md
+++ b/_includes/corridors/ugx-mobile.md
@@ -9,14 +9,14 @@ For Ugandan mobile payments please use:
 "details": {
   {{ recipient_name }},
   "phone_number": "+256772123456", // E.164 international format
-  "mobile_provider": "airtel" // optional
+  "mobile_provider": "airtel"
 }
 ```
 {% endcapture %}
 
 {% include language-tabbar.html prefix="ugx-mobile-details" raw=data-raw %}
 
-Although the `mobile_provider` field is optional, if you send us the proper value we can provider a quicker and faster settlement. The valid values are:
+The available `mobile_provider`s are:
 
 {% capture data-raw %}
 ```


### PR DESCRIPTION
Changes
---------

- Removes mentions of `mobile_provider` being optional in `UGX::Mobile` corridor.

![Screenshot 2023-05-26 at 10 42 16](https://github.com/transferzero/api-documentation/assets/40522592/3d16ae73-5d82-49d9-890a-c4edabac34fd)