### PR TITLE
BTA-11451 Add account validation support for UGX::Mobile

### DIFF
--- a/_docs/additional-features.md
+++ b/_docs/additional-features.md
@@ -39,8 +39,8 @@ POST /v1/account_validations
 
 {
   "phone_number": "+233302123456", // E.164 international format
-  "country": "GH",   // Only "GH" is supported for now
-  "currency": "GHS", // Only "GHS" is supported for now
+  "country": "GH",   // Only "GH" and "UG" are supported for now
+  "currency": "GHS", // Only "GHS" and "UGX" are supported for now
   "method": "mobile",
   "mobile_provider": "vodafone" // Optional
 }


### PR DESCRIPTION
Changes
---------

- Adds `UG` as country and `UGX` as currency in the mobile account validation example.

![Screenshot 2023-06-08 at 10 03 10](https://github.com/transferzero/api-documentation/assets/40522592/c8b14af1-4c88-40b9-9350-19853681ed59)
