### PR TITLE
BTA-11584 Add airteltigo as GHS::Mobile provider

### DIFF
--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -172,35 +172,7 @@ NG
 
 {% include corridors/ghs-bank.md recipient_type='individual' %}
 
-## GHS::Mobile
-
-For Ghanan mobile payments please use:
-
-{% capture data-raw %}
-```javascript
-"details": {
-  "first_name": "First",
-  "last_name": "Last",
-  "phone_number": "+233302123456" // E.164 international format
-  "mobile_provider": "tigo" // optional
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="ghs-mobile-details" raw=data-raw %}
-
-Although the `mobile_provider` field is optional, if you send us the proper value we can provider a quicker and faster settlement. The valid values are:
-
-{% capture data-raw %}
-```
-airtel
-mtn
-tigo
-vodafone
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="ghs-mobile-providers" raw=data-raw %}
+{% include corridors/ghs-mobile.md %}
 
 ## GHS::Cash
 

--- a/_includes/corridors/ghs-mobile.md
+++ b/_includes/corridors/ghs-mobile.md
@@ -1,0 +1,32 @@
+## GHS::Mobile
+
+For Ghanan mobile payments please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "first_name": "First",
+  "last_name": "Last",
+  "phone_number": "+233302123456" // E.164 international format
+  "mobile_provider": "airtel_tigo" // optional
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="ghs-mobile-details" raw=data-raw %}
+
+Although the `mobile_provider` field is optional, if you send us the proper value we can provider a quicker and faster settlement. The valid values are:
+
+{% capture data-raw %}
+```
+airtel_tigo
+mtn
+vodafone
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="ghs-mobile-providers" raw=data-raw %}
+
+<div class="alert alert-info" markdown="1">
+**Note:** Kindly be informed that Airtel has merged with Millicom's Tigo in Ghana to become AirtelTigo
+</div>

--- a/_includes/corridors/ghs-mobile.md
+++ b/_includes/corridors/ghs-mobile.md
@@ -8,7 +8,7 @@ For Ghanan mobile payments please use:
   "first_name": "First",
   "last_name": "Last",
   "phone_number": "+233302123456" // E.164 international format
-  "mobile_provider": "airtel_tigo" // optional
+  "mobile_provider": "vodafone" // optional
 }
 ```
 {% endcapture %}
@@ -19,7 +19,7 @@ Although the `mobile_provider` field is optional, if you send us the proper valu
 
 {% capture data-raw %}
 ```
-airtel_tigo
+airteltigo
 mtn
 vodafone
 ```


### PR DESCRIPTION
Changes
---------

- Adds `airteltigo` and removes `airtel` and `tigo` as `GHS::Mobile` allowed mobile providers.

![Screenshot 2023-06-23 at 10 08 01](https://github.com/transferzero/api-documentation/assets/40522592/210a7892-6de6-42de-87bb-83977a099725)

