### PR TITLE
BTA-11659 BRL::Bank payouts update

### DIFF
--- a/_docs/beta-payments.md
+++ b/_docs/beta-payments.md
@@ -13,6 +13,10 @@ This document lists the required details that needs to be sent for each of our p
 **Note** Occasionally there might be issues with one of the corridors and we might have to disable them temporarily. Once youre onboarded we'll let you know if this happens. Also if you're trying to use a disabled corridor you're going to receive a validation error stating that the corridor is not active, and you won't be able to create new transactions there.
 </div>
 
+# Brazil
+
+{% include corridors/brl-bank-beta.md recipient_type='individual' %}
+
 # India
 
 {% include corridors/inr-bank.md recipient_type='individual' %}

--- a/_includes/corridors/brl-bank-beta.md
+++ b/_includes/corridors/brl-bank-beta.md
@@ -15,6 +15,7 @@ For Brazilian bank account payments via PIX please use:
   {{ recipient_name }},
   "city": "Brasilia",
   "postal_code": "70070",
+  "phone_number": "+552112345678", // recipient phone number in international format
   "pix_key_type": "email",
   "pix_key_value": "person@example.com",
   "identity_card_type": "ID",
@@ -44,6 +45,7 @@ For Brazilian bank account payments using bank code and account number please us
   {{ recipient_name }},
   "city": "Brasilia",
   "postal_code": "70070",
+  "phone_number": "+552112345678", // recipient phone number in international format
   "bank_code": "104",
   "branch_code": "00001",
   "bank_account": "0009795493",


### PR DESCRIPTION
Changes
---------

- Adds `BRL::Bank` corridor to beta payments (with mandatory `phone_number`).
- Removes `phone_number` from `BRL::Bank` in individual payments.
- Updates `BRL::Bank` banks list in both beta and individual payments.

**Beta Payments:**
![Screenshot 2023-06-30 at 10 57 37](https://github.com/transferzero/api-documentation/assets/40522592/049c0318-32ae-41e6-88a8-6ea1bd4e3147)

**Individual Payments:**
![Screenshot 2023-06-30 at 10 57 00](https://github.com/transferzero/api-documentation/assets/40522592/8fc2765a-624b-4b2b-b721-0c7d974fbb8b)

**Banks List:**
![Screenshot 2023-06-30 at 11 04 56](https://github.com/transferzero/api-documentation/assets/40522592/2d2e373c-53b0-4f1a-aced-fd147ceeae64)

