### PR TITLE
BTA-11718 BRL::Bank Cleanup

### DIFF
--- a/_includes/corridors/brl-bank-beta.md
+++ b/_includes/corridors/brl-bank-beta.md
@@ -18,8 +18,7 @@ For Brazilian bank account payments via PIX please use:
   "phone_number": "+552112345678", // recipient phone number in international format
   "pix_key_type": "email",
   "pix_key_value": "person@example.com",
-  "identity_card_type": "ID",
-  "identity_card_id": "01234567890",
+  "identity_card_id": "01234567890", // CPF or CNPJ
   "transfer_reason": "personal_account"
 }
 ```
@@ -50,8 +49,7 @@ For Brazilian bank account payments using bank code and account number please us
   "branch_code": "00001",
   "bank_account": "0009795493",
   "bank_account_type": "10", // 10 for savings, 20 for current, 30 for payment, 40 for salary
-  "identity_card_type": "ID",
-  "identity_card_id": "01234567890",
+  "identity_card_id": "01234567890", // CPF or CNPJ
   "transfer_reason": "personal_account"
 }
 ```

--- a/_includes/corridors/brl-bank.md
+++ b/_includes/corridors/brl-bank.md
@@ -17,8 +17,7 @@ For Brazilian bank account payments via PIX please use:
   "postal_code": "70070",
   "pix_key_type": "email",
   "pix_key_value": "person@example.com",
-  "identity_card_type": "ID",
-  "identity_card_id": "01234567890",
+  "identity_card_id": "01234567890", // CPF or CNPJ
   "transfer_reason": "personal_account"
 }
 ```
@@ -48,8 +47,7 @@ For Brazilian bank account payments using bank code and account number please us
   "branch_code": "00001",
   "bank_account": "0009795493",
   "bank_account_type": "10", // 10 for savings, 20 for current, 30 for payment, 40 for salary
-  "identity_card_type": "ID",
-  "identity_card_id": "01234567890",
+  "identity_card_id": "01234567890", // CPF or CNPJ
   "transfer_reason": "personal_account"
 }
 ```


### PR DESCRIPTION
Changes
---------

- Removes `identity_card_type` from `BRL::Bank` documentation and adds ID types next to `identity_card_id` example in individual and beta payments pages.

**Individual**
![Individual](https://github.com/transferzero/api-documentation/assets/40522592/a2028d9d-909b-4a98-878d-bcadd2f1c62e)

**Beta**
![beta](https://github.com/transferzero/api-documentation/assets/40522592/312f35b4-1b0e-4f3e-b6b3-58d9646ff4d8)

