### PR TITLE
[BTA-12047] Update docs for Providus NGN bank codes

### DIFF
--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -64,6 +64,16 @@ Unity Bank: 215
 VFD Microfinance Bank: 566
 Wema Bank: 035
 Zenith International: 057
+---
+Carbon / One Finance: 100026
+Fairmoney Microfinance Bank LTD: 090551
+Go Money: 100022
+Kuda Microfinance Bank: 090267
+Moniepoint Microfinance Bank: 090405
+Opay: 100004
+Palmpay: 100033
+Providus Bank: 000023
+VFD Microfinance Bank: 090110
 ```
 {% endcapture %}
 

--- a/_docs/transaction-flow.md
+++ b/_docs/transaction-flow.md
@@ -1095,7 +1095,16 @@ A transaction object looks like the following:
                 "215": "Unity Bank",
                 "566": "VFD Microfinance Bank",
                 "035": "Wema Bank",
-                "057": "Zenith International "
+                "057": "Zenith International ",
+                "100026": "Carbon / One Finance",
+                "090551": "Fairmoney Microfinance Bank LTD",
+                "100022": "Go Money",
+                "090267": "Kuda Microfinance Bank",
+                "090405": "Moniepoint Microfinance Bank",
+                "100004": "Opay",
+                "100033": "Palmpay",
+                "000023": "Providus Bank",
+                "090110": "VFD Microfinance Bank"
               },
               "validations": {
                 "presence": true,
@@ -1126,7 +1135,16 @@ A transaction object looks like the following:
                     "215": "Unity Bank",
                     "566": "VFD Microfinance Bank",
                     "035": "Wema Bank",
-                    "057": "Zenith International "
+                    "057": "Zenith International ",
+                    "100026": "Carbon / One Finance",
+                    "090551": "Fairmoney Microfinance Bank LTD",
+                    "100022": "Go Money",
+                    "090267": "Kuda Microfinance Bank",
+                    "090405": "Moniepoint Microfinance Bank",
+                    "100004": "Opay",
+                    "100033": "Palmpay",
+                    "000023": "Providus Bank",
+                    "090110": "VFD Microfinance Bank"
                   }
                 }
               }


### PR DESCRIPTION
- Update docs for Providus NGN bank codes

```
['101']='PROVIDUS BANK'  ['000023']
['611']='KUDA MICROFINANCE BANK' ['090267']
['305']='OPAY' ['100004']
['B54']='PALMPAY' ['100033']
['566']='VFD MICROFINANCE BANK' ['090110']
['565']='CARBON / ONE FINANCE' ['100026']
['993']='MONIEPOINT MICROFINANCE BANK' ['090405']
['E30']='FAIRMONEY MICROFINANCE BANK LTD' ['090551']
['326']='GO MONEY' ['100022']
```