### PR TITLE
Add Proof of payment to menu in Get Started

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -4,6 +4,7 @@
     - quick-integration
     - example-payments
     - example-collections
+    - additional-features#proof-of-payment
 
 - title: SDKs
   docs:

--- a/_includes/docs_nav.html
+++ b/_includes/docs_nav.html
@@ -11,9 +11,16 @@
     <div id="collapse-{{forloop.index}}" class="panel-collapse collapse" role="tabpanel" aria-label="Side Navigation">
       <div class="list-group">
         {% for item in section.docs %}
-          {% assign item_url = item | prepend:"/docs/" | append:"/" %}
+          {% assign split_item = item | split: "#" %}
+          {% assign item_url = split_item[0] | prepend:"/docs/" | append:"/" %}
           {% assign p = site.docs | where:"url", item_url | first %}
-          <a class="list-group-item {% if item_url == page.url %}active{% endif %}" href="{{ p.url  | prepend: site.baseurl }}">{{ p.title }}</a>
+          {% if item contains "#" %}
+            {% capture full_url %}{{ p.url | prepend: site.baseurl }}#{{ split_item[1] }}{% endcapture %}
+            {% assign section_name = split_item[1] | replace: "-", " " | capitalize %}
+            <a class="list-group-item {% if item_url == page.url %}active{% endif %}" href="{{ full_url }}">{{ section_name }}</a>
+          {% else %}
+            <a class="list-group-item {% if item_url == page.url %}active{% endif %}" href="{{ p.url  | prepend: site.baseurl }}">{{ p.title }}</a>
+          {% endif %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
This PR is adding a new menu item in Get Started. It modifies the template in order to be able to reconstruct the correct URL and menu item name when an ID is passed

![CleanShot 2023-08-29 at 16 42 14](https://github.com/transferzero/api-documentation/assets/40179292/881c8859-2e1c-48ed-8ca4-f59879d1bae1)

![CleanShot 2023-08-29 at 16 42 27](https://github.com/transferzero/api-documentation/assets/40179292/10df3ff6-fd90-453f-85fa-979332a8894c)
