### PR TITLE
BTA-12353 Optional ugx:bank postal code

### DIFF
--- a/_includes/corridors/ugx-bank.md
+++ b/_includes/corridors/ugx-bank.md
@@ -10,7 +10,7 @@ For Ugandan bank payments please use:
   {{ recipient_name }},
   "street": "1 Old Taxi Park",
   "city": "Kampala",
-  "postal_code": "10102",
+  "postal_code": "10102", // optional
   "identity_card_id": "3081900101123411",
   "bank_account": "1234567890",
   "branch_code": "130547",


### PR DESCRIPTION
Adding comment about optional 'postal_code' param for UGX::Bank corridor