### PR TITLE
Add changelog for PHP SDK version 

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,12 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current version of the SDKs are `1.32.1`
+Current version of the SDKs are `1.33.0`
+
+1.33.0
+------
+* [PHP SDK] Drop support for PHP 7.1
+* [PHP SDK] Upgrade Guzzlehttp to 7.3
 
 1.32.1
 ------


### PR DESCRIPTION
This PR adds changelog entry for the PHP SDK version upgrade. See https://github.com/bitpesa/bitpesa-api-specification/pull/380