### PR TITLE
Bta 12636 Add support for Nigeria USD::Bank payouts 

### DIFF
--- a/_docs/business-payments.md
+++ b/_docs/business-payments.md
@@ -450,3 +450,7 @@ The valid values for the industry / nature of business are the following:
 # Egypt
 
 {% include corridors/egp-bank.md recipient_type='business' %}
+
+# Nigeria
+
+{% include corridors/usd-bank.md recipient_type='business' %}

--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -94,54 +94,7 @@ For Nigerian mobile payments please use:
 **Warning!** The recipient has to be registered and KYC'd with <https://www.mypaga.com>{: .alert-link} before they can receive funds. If they are not registered when the payment occurs then Paga can hold the funds until the user registers and approves themselves.
 </div>
 
-## USD::Bank
-
-For USD bank payments in Nigeria please use:
-
-{% capture data-raw %}
-```javascript
-"details": {
-  "first_name": "Jane",
-  "last_name": "Doe",
-  "phone_number": "+2347087661234", // optional - E.164 international format
-  "bank_code": "057",
-  "bank_account": "1234567890",
-  "country": "NG"
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="usd-bank-details" raw=data-raw %}
-
-The valid `bank_code` values are:
-
-{% capture data-raw %}
-```
-Access Bank: 044
-FCMB Bank: 214
-Fidelity Bank: 070
-Union Bank: 032
-United Bank for Africa: 033
-Zenith International: 057
-Polaris Bank: 076
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="usd-bank-details" raw=data-raw %}
-
-The valid `country` values are:
-
-{% capture data-raw %}
-```
-NG
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="usd-bank-countries" raw=data-raw %}
-
-<div class="alert alert-warning" markdown="1">
-**Warning** `USD::Bank` payouts in Nigeria are currently in beta phase.
-</div>
+{% include corridors/usd-bank.md recipient_type='individual' %}
 
 ## USD::Cash
 
@@ -169,6 +122,10 @@ NG
 {% endcapture %}
 
 {% include language-tabbar.html prefix="usd-cash-countries" raw=data-raw %}
+
+All individual senders trying to create Nigerian USD bank or cash payouts need to have the following details present:
+
+- `"birth_date" => "1993-07-23"`
 
 <div class="alert alert-warning" markdown="1">
 **Warning** `USD::Cash` payouts in Nigeria are currently in beta phase.

--- a/_includes/corridors/usd-bank.md
+++ b/_includes/corridors/usd-bank.md
@@ -1,0 +1,56 @@
+{% include corridors/recipient_name.md %}
+
+## USD::Bank
+
+For USD bank payments in Nigeria please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  {{ recipient_name }},
+  "phone_number": "+2347087661234", // optional - E.164 international format
+  "bank_code": "057",
+  "bank_account": "1234567890",
+  "country": "NG"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="usd-bank-details" raw=data-raw %}
+
+The valid `bank_code` values are:
+
+{% capture data-raw %}
+```
+Access Bank: 044
+FCMB Bank: 214
+Fidelity Bank: 070
+Union Bank: 032
+United Bank for Africa: 033
+Zenith International: 057
+Polaris Bank: 076
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="usd-bank-details" raw=data-raw %}
+
+The valid `country` values are:
+
+{% capture data-raw %}
+```
+NG
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="usd-bank-countries" raw=data-raw %}
+
+{% if include.recipient_type == 'individual' %}
+All individual senders trying to create Nigerian USD bank or cash payouts need to have the following details present:
+
+- `"birth_date" => "1993-07-23"`
+{% endif %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning** `USD::Bank` payouts in Nigeria are currently in beta phase.
+</div>
+


### PR DESCRIPTION
[BTA-12636 ](https://azafinance.atlassian.net/browse/BTA-12636): Add support for Nigeria USD::Bank payouts
Update Nigeria USD::Bank & USD::Cash sender requirements

Nigeria USD::Bank Business Payments
![Screenshot 2023-11-10 at 16 41 01](https://github.com/transferzero/api-documentation/assets/17137356/1f42eff9-9010-41c3-acb2-03f20baf516a)


Nigeria USD::Bank Individual sender Details Update
![Screenshot 2023-11-10 at 16 34 43](https://github.com/transferzero/api-documentation/assets/17137356/4a420203-8433-4471-94bb-25fd83609427)


Nigeria USD::Cash Individual sender Details Update
![Screenshot 2023-11-10 at 16 32 29](https://github.com/transferzero/api-documentation/assets/17137356/fe5930f2-b3a2-4866-8cb9-dce46999d0c9)
