### PR TITLE
BTA-12546 USD::Bank payouts in Egypt

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current version of the SDKs are `1.33.0`
+Current versions of the SDKs are `1.34.0`
+
+1.34.0
+------
+* Add support for `USD::Bank` payouts in Egypt.
 
 1.33.0
 ------

--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current versions of the SDKs are `1.34.0`
+Current versions of the SDKs are `1.34.1`
+
+1.34.1
+------
+* Add Bank of Baroda to KES::Bank banks list.
 
 1.34.0
 ------

--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -12,7 +12,7 @@ Current versions of the SDKs are `1.34.1`
 
 1.34.1
 ------
-* Add Bank of Baroda to KES::Bank banks list.
+* Add Bank of Baroda to `KES::Bank` banks list.
 
 1.34.0
 ------

--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -289,3 +289,5 @@ mtn
 # Egypt
 
 {% include corridors/egp-bank.md recipient_type='individual' %}
+
+{% include corridors/usd-bank-egypt.md recipient_type='individual' %}

--- a/_docs/transaction-flow.md
+++ b/_docs/transaction-flow.md
@@ -1363,8 +1363,10 @@ Funding transactions can be done using the `POST /v1/accounts/debits` endpoint, 
 {% capture data-raw %}
 ```javascript
 {
-  "to_id": "5f44026b-7904-4c30-87d6-f8972d790ded",
-  "to_type": "Transaction"
+  "debit": {
+    "to_id": "5f44026b-7904-4c30-87d6-f8972d790ded",
+    "to_type": "Transaction"
+  }
 }
 ```
 {% endcapture %}
@@ -1376,10 +1378,12 @@ You can also supply the `currency` and `amount` parameters, in which case we'll 
 {% capture data-raw %}
 ```javascript
 {
-  "currency": "NGN",
-  "amount": "2000.0",
-  "to_id": "5f44026b-7904-4c30-87d6-f8972d790ded",
-  "to_type": "Transaction"
+  "debit":{
+    "currency": "NGN",
+    "amount": "2000.0",
+    "to_id": "5f44026b-7904-4c30-87d6-f8972d790ded",
+    "to_type": "Transaction"
+  }
 }
 ```
 {% endcapture %}

--- a/_includes/corridors/usd-bank-egypt.md
+++ b/_includes/corridors/usd-bank-egypt.md
@@ -12,6 +12,7 @@ For USD bank payments in Egypt please use:
   "phone_number": "+201023456789",
   "iban": "EG380019000500000000263180002",
   "transfer_reason": "personal_account",
+  "country": "EG"
 }
 ```
 {% endcapture %}

--- a/_includes/corridors/usd-bank-egypt.md
+++ b/_includes/corridors/usd-bank-egypt.md
@@ -1,0 +1,177 @@
+{% include corridors/recipient_name.md %}
+
+## USD::Bank
+
+For USD bank payments in Egypt please use:
+
+{% capture data-raw %}
+```javascript
+ "details": {
+  {{ recipient_name }},
+  "street": "1 Main Street",
+  "phone_number": "+201023456789",
+  "iban": "EG380019000500000000263180002",
+  "transfer_reason": "personal_account",
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix=usd-bank-egypt-details  raw=data-raw %}
+
+{% if include.recipient_type == 'individual' %}
+Although the `middle_name` field is optional, having the full name (first, middle and last name as stated on the government issued ID) of the beneficiary is a regulatory requirement and will ensure faster settlement due to less regulatory screening time.
+{% endif %}
+
+The currently supported banks and their bank codes are:
+
+{% capture data-raw %}
+```
+ABU DHABI COMMERCIAL BANK EGYPT: 0027
+ABU DHABI ISLAMIC BANK: 0030
+AHLY UNITED BANK: 0020
+AL AHLI BANK OF KUWAIT - EGYPT S.A.E: 0018
+AL BARAKA BANK EGYPT: 0022
+ARAB AFRICAN INTERNATIONAL BANK: 0057
+ARAB BANK: 0044
+ARAB BANKING CORPORATION: 0040
+ARAB INVESTMENT BANK: 0058
+ARAB INTERNATIONAL BANK: 0056
+ATTIJARIWAFA BANK - EGYPT S.A.E: 0034
+BANK OF ALEXANDRIA: 0005
+BANQUE DU CAIRE: 0004
+BANQUE MISR: 0002
+BLOM BANK EGYPT: 0013
+CITIBANK: 0043
+COMMERCIAL INTERNATIONAL BANK: 0010
+CREDIT AGRICOLE EGYPT: 0036
+EGYPT POST: 9002
+EGYPTIAN ARAB LAND BANK: 0007
+EGYPTIAN GULF BANK: 0029
+EMIRATES NATIONAL BANK OF DUBAI: 0014
+EXPORT DEVELOPMENT BANK OF EGYPT: 0061
+FAISAL ISLAMIC BANK OF EGYPT: 0059
+FIRST ABU DHABI BANK (formerly NATIONAL BANK OF ABU DHABI): 0019
+HOUSING AND DEVELOPMENT BANK: 0038
+HSBC: 0025
+INDUSTRIAL DEVELOPMENT BANK OF EGYPT: 0008
+MASHREQ BANK: 0046
+MISR IRAN DEVELOPMENT BANK: 0033
+NATIONAL BANK OF EGYPT: 0003
+NATIONAL BANK OF GREECE: 0048
+NATIONAL BANK OF KUWAIT-EGYPT: 0023
+PRINCIPAL BANK FOR DEVELOPMENT AND AGRI.: 0009
+QATAR NATIONAL BANK ALAHLI: 0037
+SOCIETE ARABE INTER. DE BANQUE: 0035
+SUEZ CANAL BANK: 0017
+UNITED BANK: 0031
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix=usd-bank-egypt-options  raw=data-raw %}
+
+{% include corridors/transfer_reasons.md %}
+
+{% if include.recipient_type == 'individual' %}
+  <div class="alert alert-info" markdown="1">
+  **Note:** Both Individual and Business senders (C2C, B2C) can be used for USD bank payouts in Egypt.
+  </div>
+
+  **Individual Senders** trying to create USD bank payouts in Egypt need to have the following details present:
+  - `"identification_type" => "ID"`
+  - `"identification_number" => "AB12345678"`
+  - `"street" => "1, Main Street"`
+  - `"birth_date" => "1983-01-01"`
+
+  {% include corridors/identification_types.md %}
+
+  {% include language-tabbar.html prefix="usd-bank-egypt-identification-types" raw=data-raw %}
+
+  **Business Senders** trying to create USD bank payouts in Egypt need to have the following details present:
+  - `"registration_number" => "AB12345678"`
+  - `"registration_date" => "2020-01-01"`
+  - `"street" => "1, Main Street"`
+
+{% else %}
+  <div class="alert alert-info" markdown="1">
+  **Note:** Only Individual senders (C2B) can be used for USD bank payouts in Egypt. Support for business senders (B2B) is coming soon!
+  </div>
+
+  **Individual Senders** trying to create USD bank payouts in Egypt need to have the following details present:
+  - `"identification_type" => "ID"`
+  - `"identification_number" => "AB12345678"`
+  - `"street" => "1, Main Street"`
+  - `"birth_date" => "1983-01-01"`
+
+  {% include corridors/identification_types.md %}
+
+  {% include language-tabbar.html prefix="usd-bank-egypt-identification-types" raw=data-raw %}
+{% endif %}
+
+Please note that the fields above are generally considered optional for senders for other payment corridors. If you wish to use an existing sender who has some of these fields missing you can provide them alongside the `id` or `external_id` field in the sender details. For example:
+
+{% if include.recipient_type == 'individual' %}
+  **For Individual Senders:**
+  {% capture data-raw %}
+  ```javascript
+  {
+    "transaction": {
+      "sender": {
+        "external_id": "<id of sender>",
+        "identification_type": "ID",
+        "identification_number": "AB12345678",
+        "street" => "1, Main Street",
+        "birth_date" => "1983-01-01",
+        (...)
+      },
+      (...)
+    }
+  }
+  ```
+  {% endcapture %}
+
+  {% include language-tabbar.html prefix="usd-bank-egypt-sender-details" raw=data-raw %}
+
+  **For Business Senders:**
+  {% capture data-raw %}
+  ```javascript
+  {
+    "transaction": {
+      "sender": {
+        "external_id": "<id of sender>",
+        "registration_number": "AB12345678",
+        "registration_date": "2020-01-01",
+        "street" => "1, Main Street",
+        (...)
+      },
+      (...)
+    }
+  }
+  ```
+  {% endcapture %}
+{% else %}
+  {% capture data-raw %}
+  ```javascript
+  {
+    "transaction": {
+      "sender": {
+        "external_id": "<id of sender>",
+        "identification_type": "ID",
+        "identification_number": "AB12345678",
+        "phone_number" => "+201023456789",
+        "email" => "test.sender@email.com",
+        "street" => "1, Main Street",
+        "birth_date" => "1983-01-01",
+        (...)
+      },
+      (...)
+    }
+  }
+  ```
+  {% endcapture %}
+{% endif %}
+
+{% include language-tabbar.html prefix="usd-bank-egypt-sender-details" raw=data-raw %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning** `USD::Bank` payouts in Egypt are currently in beta phase.
+</div>


### PR DESCRIPTION
BTA-12546: USD::Bank payouts in Egypt

Changes
---------

- Adds support for `USD::Bank` payouts in Egypt.

![Screenshot 2024-01-19 at 15 20 34](https://github.com/transferzero/api-documentation/assets/40522592/90261cf9-7f61-43c7-a9d1-14d3cad10ad0)
![Screenshot 2024-01-19 at 15 20 52](https://github.com/transferzero/api-documentation/assets/40522592/01706448-f7a7-4cd0-9267-39ae199f5344)
![Screenshot 2024-01-19 at 15 21 04](https://github.com/transferzero/api-documentation/assets/40522592/bcbfca00-0cff-4adf-bc84-04b2308d3579)
![Screenshot 2024-01-19 at 15 21 13](https://github.com/transferzero/api-documentation/assets/40522592/df84d170-72a8-4775-b200-7afdee1d7e54)
![Screenshot 2024-01-19 at 15 25 14](https://github.com/transferzero/api-documentation/assets/40522592/78802dfc-a62e-42e7-87ef-39171cd8b7c8)
