### PR TITLE
BTA-13678 Add support for additional XAF countries

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current versions of the SDKs are `1.34.1`
+Current versions of the SDKs are `1.35.0`
+
+1.35.0
+------
+* Add support for `CF`, `CG`, `GA` and `TD` CEMAC countries to `XAF::Mobile`.
 
 1.34.1
 ------

--- a/_docs/individual-payments.md
+++ b/_docs/individual-payments.md
@@ -191,34 +191,7 @@ Please note that the fields above are generally considered optional for senders 
 
 {% include corridors/xaf-bank.md recipient_type='individual' %}
 
-## XAF::Mobile
-
-For mobile payouts to Cameroon, please use:
-
-{% capture data-raw %}
-```javascript
-"details": {
-  "first_name": "First",
-  "last_name": "Last",
-  "mobile_provider": "orange", // lowercase, see provider values below
-  "phone_number": "+237674044436", // E.164 international format
-  "country": "CM" // "CM" for Cameroon
-}
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="xaf-mobile-details" raw=data-raw %}
-
-The valid `mobile_provider` values for Cameroon are:
-
-{% capture data-raw %}
-```
-orange
-mtn
-```
-{% endcapture %}
-
-{% include language-tabbar.html prefix="xaf-mobile-providers" raw=data-raw %}
+{% include corridors/xaf-mobile.md %}
 
 # Guinea
 

--- a/_includes/corridors/xaf-mobile.md
+++ b/_includes/corridors/xaf-mobile.md
@@ -1,0 +1,90 @@
+## XAF::Mobile
+
+For mobile payouts to countries in the CEMAC region, please use:
+
+{% capture data-raw %}
+```javascript
+"details": {
+  "first_name": "First",
+  "last_name": "Last",
+  "mobile_provider": "orange", // lowercase, see provider values below
+  "phone_number": "+237674044436", // E.164 international format
+  "country": "CM"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-details" raw=data-raw %}
+
+The available `country`s are:
+
+{% capture data-raw %}
+```
+CF: Central African Republic
+CG: Congo
+CM: Cameroon
+GA: Gabon
+TD: Chad
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-details" raw=data-raw %}
+
+The valid `mobile_provider` values for the Central African Republic are:
+
+{% capture data-raw %}
+```
+orange
+telecel
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-providers" raw=data-raw %}
+
+The valid `mobile_provider` values for Chad are:
+
+{% capture data-raw %}
+```
+airtel
+moov
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-providers" raw=data-raw %}
+
+The valid `mobile_provider` values for Cameroon are:
+
+{% capture data-raw %}
+```
+orange
+mtn
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-providers" raw=data-raw %}
+
+The valid `mobile_provider` values for Congo are:
+
+{% capture data-raw %}
+```
+airtel
+mtn
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-providers" raw=data-raw %}
+
+The valid `mobile_provider` values for Gabon are:
+
+{% capture data-raw %}
+```
+airtel
+moov
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-providers" raw=data-raw %}
+
+<div class="alert alert-warning" markdown="1">
+**Warning** `XAF::Mobile` payouts to **Central African Republic, Chad, Congo and Gabon** are currently in Beta phase.
+</div>


### PR DESCRIPTION
BTA-13678 Add support for additional XAF countries

Changes
---------

- Add support for `CF`, `CG`, `GA` and `TD` CEMAC countries to `XAF::Mobile`.