### PR TITLE
BTA-14455 EGP::Cash reference and recipient email

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current versions of the SDKs are `1.36.2`
+Current version of the SDKs is `1.36.3`
+
+1.36.3
+------
+* Add optional `email` field for individual payouts on the `EGP::Cash` corridor.
 
 1.36.2
 ------

--- a/_includes/corridors/egp-cash.md
+++ b/_includes/corridors/egp-cash.md
@@ -10,7 +10,8 @@ For Egyptian cash payments please use:
   "last_name": "Last",
   "phone_number": "+201023456789",
   "street": "1 Main Street",
-  "transfer_reason": "personal_account"
+  "transfer_reason": "personal_account",
+  "email": "recipient@email.com" // optional
 }
 ```
 {% endcapture %}


### PR DESCRIPTION
BTA-14455 EGP::Cash reference and recipient email

Changes
---------

- Add optional `email` field for individual payouts on the `EGP::Cash` corridor and updates `changelog.md`.

![egp cash docs email](https://github.com/user-attachments/assets/c785019f-1d55-41aa-8355-1b9b8fcb83c2)

![docs changelog](https://github.com/user-attachments/assets/482ed4e2-444c-4cd3-a4b7-e53d9c77716b)
