### PR TITLE
BTA-14522 Make EGP::Cash middle name field mandatory

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current version of the SDKs is `1.36.3`
+Current version of the SDKs is `1.36.4`
+
+1.36.4
+------
+* Makes `middle_name` field mandatory for the `EGP::Cash` corridor.
 
 1.36.3
 ------

--- a/_includes/corridors/egp-cash.md
+++ b/_includes/corridors/egp-cash.md
@@ -18,8 +18,6 @@ For Egyptian cash payments please use:
 
 {% include language-tabbar.html prefix=egp-cash-details  raw=data-raw %}
 
-Although the `middle_name` field is optional, having the full name (first, middle and last name as stated on the government issued ID) of the beneficiary is a regulatory requirement and will ensure faster settlement due to less regulatory screening time.
-
 {% include corridors/transfer_reasons.md %}
 
 {% if include.recipient_type == 'individual' %}


### PR DESCRIPTION
BTA-14522 Make EGP::Cash middle name field mandatory

Changes
---------

- Makes `EGP::Cash` middle name field mandatory and updates the changelog.