### PR TITLE
BTA-14829: Add phone number for egypt must be an egyptian number

### DIFF
--- a/_includes/corridors/egp-bank.md
+++ b/_includes/corridors/egp-bank.md
@@ -9,7 +9,7 @@ For Egyptian bank payments please use:
 "details": {
   {{ recipient_name }},
   "street": "1 Main Street",
-  "phone_number": "+201023456789", // optional
+  "phone_number": "+201023456789", // optional, must be EG number
   "bank_code": "0030",
   "bank_account": "1234567890",
   "transfer_reason": "personal_account",

--- a/_includes/corridors/egp-cash.md
+++ b/_includes/corridors/egp-cash.md
@@ -8,7 +8,7 @@ For Egyptian cash payments please use:
   "first_name": "First",
   "middle_name": "Middle",
   "last_name": "Last",
-  "phone_number": "+201023456789",
+  "phone_number": "+201023456789", // must be EG number
   "street": "1 Main Street",
   "transfer_reason": "personal_account",
   "email": "recipient@email.com" // optional

--- a/_includes/corridors/usd-bank-egypt.md
+++ b/_includes/corridors/usd-bank-egypt.md
@@ -9,7 +9,7 @@ For USD bank payments in Egypt please use:
  "details": {
   {{ recipient_name }},
   "street": "1 Main Street",
-  "phone_number": "+201023456789", // optional
+  "phone_number": "+201023456789", // optional, must be EG number
   "iban": "EG380019000500000000263180002",
   "transfer_reason": "personal_account",
   "country": "EG"


### PR DESCRIPTION
BTA-14829: Add phone number for egypt must be an egyptian number

Add clarification to API docs: Phone number for Egypt must be Egyptian number

<img width="762" alt="Screenshot 2025-01-20 at 11 07 49" src="https://github.com/user-attachments/assets/725593fb-4d0f-43ad-9c22-4b971fb9a0e4" />
<img width="882" alt="Screenshot 2025-01-20 at 11 08 06" src="https://github.com/user-attachments/assets/317a1098-a125-494a-af62-8a408c89ca67" />
<img width="941" alt="Screenshot 2025-01-20 at 11 08 17" src="https://github.com/user-attachments/assets/ba444e80-4187-45d3-9857-b68d207a548a" />

