### PR TITLE
BTA-14899: Make mobile_provider mandatory and add transfer_reason to ghs corridor

### DIFF
--- a/_includes/corridors/ghs-bank.md
+++ b/_includes/corridors/ghs-bank.md
@@ -9,7 +9,8 @@ For Ghanan bank payments please use:
 "details": {
   {{ recipient_name }},
   "bank_code": "030100",
-  "bank_account": "123456789"
+  "bank_account": "123456789",
+  "transfer_reason": "third_party_person_account"
 }
 ```
 {% endcapture %}
@@ -81,3 +82,5 @@ Zenith Bank: 10 digits
 {% endcapture %}
 
 {% include language-tabbar.html prefix="ghs-bank-digits" raw=data-raw %}
+
+{% include corridors/transfer_reasons.md %}

--- a/_includes/corridors/ghs-mobile.md
+++ b/_includes/corridors/ghs-mobile.md
@@ -8,7 +8,8 @@ For Ghanan mobile payments please use:
   "first_name": "First",
   "last_name": "Last",
   "phone_number": "+233302123456" // E.164 international format
-  "mobile_provider": "vodafone" // optional
+  "mobile_provider": "vodafone",
+  "transfer_reason": "third_party_person_account"
 }
 ```
 {% endcapture %}
@@ -26,6 +27,8 @@ vodafone
 {% endcapture %}
 
 {% include language-tabbar.html prefix="ghs-mobile-providers" raw=data-raw %}
+
+{% include corridors/transfer_reasons.md %}
 
 <div class="alert alert-info" markdown="1">
 **Note:** Kindly be informed that Airtel has merged with Millicom's Tigo in Ghana to become AirtelTigo


### PR DESCRIPTION
BTA-14899: Make mobile_provider mandatory and add transfer_reason to ghs corridor

- Makes `mobile_provider` a mandatory field for GHS::Mobile Corridor.
- Adds `transfer_reason` as mandatory field in GHS::Mobile GHS::Bank (individuals + businesses) & GHS::Mobile (individuals)
- Adds the list of transfer_reasons within each section

<img width="767" alt="Screenshot 2025-01-20 at 13 05 35" src="https://github.com/user-attachments/assets/db8910af-9c51-4040-b2e1-71c3cce076c5" />
<img width="703" alt="Screenshot 2025-01-20 at 13 06 10" src="https://github.com/user-attachments/assets/5066b524-88d0-46e1-a156-15793c9b5626" />
<img width="832" alt="Screenshot 2025-01-20 at 13 06 39" src="https://github.com/user-attachments/assets/1f3ef11f-b590-44a6-872e-03ea1f6f5cca" />
