### PR TITLE
BTA-15195 Add wave to XOF::Mobile in SN and CI

### DIFF
--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current version of the SDKs is `1.36.4`
+Current version of the SDKs is `1.36.7`
+
+1.36.7
+------
+* Adds support for `wave` as `mobile_provider` for `XOF::Mobile` payouts in Ivory Coast and Senegal.
 
 1.36.4
 ------

--- a/_includes/corridors/xof-mobile.md
+++ b/_includes/corridors/xof-mobile.md
@@ -9,7 +9,7 @@ For mobile payouts to countries in the WAEMU region please use :
   "last_name": "Last",
   "mobile_provider": "orange", // lowercase, see provider values below
   "phone_number": "+221774044436", // mobile number in E.164 international format
-  "country": "SN" 
+  "country": "SN"
   "transfer_reason": "personal_account" // optional
 }
 ```
@@ -22,10 +22,10 @@ The available `country`s are:
 {% capture data-raw %}
 ```
 BJ: Benin
-BF: Burkina Faso 
-CI: Ivory Coast 
-SN: Senegal 
-TG: Togo 
+BF: Burkina Faso
+CI: Ivory Coast
+SN: Senegal
+TG: Togo
 ```
 {% endcapture %}
 
@@ -60,6 +60,7 @@ The valid `mobile_provider` values for Ivory Coast are:
 moov
 mtn
 orange
+wave
 ```
 {% endcapture %}
 
@@ -70,8 +71,9 @@ The valid `mobile_provider` values for Senegal are:
 {% capture data-raw %}
 ```
 expresso
-orange
 free
+orange
+wave
 ```
 {% endcapture %}
 


### PR DESCRIPTION
BTA-15195 Add wave to XOF::Mobile in SN and CI

Changes
-------

- Adds `wave` to `XOF::Mobile` providers in Senegal and Ivory Coast.
- Updates the changelog with the updated SDKs changes and version.

**XOF::Mobile SN and CI providers**
![wave docs](https://github.com/user-attachments/assets/2619e881-1b48-41cf-adfe-e16ecc34b898)

**Changelog**
![changelog](https://github.com/user-attachments/assets/9000e8a0-2f35-4505-96b3-7297f82b63be)
