### PR TITLE
BTA-15285 XAF::Mobile account validation

### DIFF
--- a/_docs/account-validation.md
+++ b/_docs/account-validation.md
@@ -9,9 +9,9 @@ permalink: /docs/account-validation/
 Since it's easy to mistype the account number or mobile number for a recipient, we provide a feature where you can
 request more details about an account number, before creating a transaction.
 
-We support this feature in 2 ways:
-- **A standalone endpoint** (for both account name enquiry and telco validation - depending on the market).
-- **An account name validation functionality within the transaction flow.**
+We support this feature in 2 ways (for account name enquiry, telco validation or account status validation - depending on the market):
+- **A standalone account validation endpoint**
+- **An account validation functionality within the transaction flow.**
 
 # Account name validation via endpoint
 
@@ -158,7 +158,7 @@ An invalid account response will return a `422 Unprocessably Entity` status code
 
 {% include language-tabbar.html prefix="invalid-account-response" raw=data-raw %}
 
-If we are unable to verify an account due to issues with validation providers (such as a timeout or other connectivity problems), we will return a `422 Unprocessable Entity` status code, along with an `Account validation failed` `error` in the `meta` object:
+If we are unable to verify an account due to issues with validation providers (such as a timeout or other connectivity problems), we will return a `422 Unprocessable Entity` status code, along with an empty `object` and an `Account validation failed` `error` in the `meta` object:
 
 {% capture data-raw %}
 ```javascript
@@ -193,6 +193,35 @@ Once you have the mobile provider (returned as `mapped_mobile_provider` in the r
 
 We support mobile provider (telco) validation in the following markets:
 
+## CEMAC Region / XAF
+### XAF::Mobile
+
+{% capture data-raw %}
+```javascript
+Request
+
+{
+  "phone_number": "+237674044436", // E.164 international format
+  "mobile_provider": "orange",
+  "country": "CM",
+  "currency": "XAF",
+  "method": "mobile"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-telco-validation" raw=data-raw %}
+
+The valid `mobile_provider` values for Cameroon are:
+
+{% capture data-raw %}
+```
+orange
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-cm-mobile-providers" raw=data-raw %}
+
 ## WAEMU Region / XOF
 ### XOF::Mobile
 
@@ -210,7 +239,7 @@ Request
 ```
 {% endcapture %}
 
-{% include language-tabbar.html prefix="xof-mobile-name-validation" raw=data-raw %}
+{% include language-tabbar.html prefix="xof-mobile-telco-validation" raw=data-raw %}
 
 The valid `mobile_provider` values for Benin are:
 
@@ -302,7 +331,98 @@ An invalid mobile provider response will return a `422 Unprocessably Entity` sta
 
 {% include language-tabbar.html prefix="invalid-telco-response" raw=data-raw %}
 
-If we are unable to verify a mobile provider due to issues with validation providers (such as a timeout or other connectivity problems), we will return a `422 Unprocessable Entity` status code, along with an `Account validation failed` `error` in the `meta` object:
+If we are unable to verify a mobile provider due to issues with validation providers (such as a timeout or other connectivity problems), we will return a `422 Unprocessable Entity` status code, along with an empty `object` and an `Account validation failed` `error` in the `meta` object:
+
+{% capture data-raw %}
+```javascript
+{
+  "object": {},
+  "meta": {
+    "error": "Account validation failed"
+  }
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="account-validation-failed-response" raw=data-raw %}
+
+# Account status validation via endpoint
+
+You can perform an account status validation by initiating a call to the following endpoint:
+
+<div class="highlight">
+  <p class="hll"><strong>POST</strong> <code>/v1/account_validations</code></p>
+</div>
+
+<div class="alert alert-info" markdown="1">
+  **Note:** Kindly be aware that this is a paid service. Please contact our Sales Team at `corporate.sales@azafinance.com` or our Account Management team at `account.mgt@azafinance.com` to request more informations.
+</div>
+
+We support account status validation in the following markets:
+
+## CEMAC Region / XAF
+### XAF::Mobile
+
+{% capture data-raw %}
+```javascript
+Request
+
+{
+  "phone_number": "+237674044436", // E.164 international format
+  "mobile_provider": "mtn",
+  "country": "CM",
+  "currency": "XAF",
+  "method": "mobile"
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-mobile-account-status-validation" raw=data-raw %}
+
+The valid `mobile_provider` values for account status validation in Cameroon are:
+
+{% capture data-raw %}
+```
+mtn
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="xaf-cm-mobile-providers" raw=data-raw %}
+
+## Responses
+
+A successful response will return a `200 OK` status code, and provide you with an `account_status` `active` attribute in the `object`:
+
+{% capture data-raw %}
+```javascript
+{
+  "object": {
+    "account_status": "active"
+  }
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="successful-telco-validation-response" raw=data-raw %}
+
+An invalid account status response will return a `422 Unprocessably Entity` status code, with an `account_status` `inactive` attribute in the `object`, and an `error` description in the `meta` object (please do note the `error` below it's just an example and it may vary depending on the market):
+
+{% capture data-raw %}
+```javascript
+{
+  "object": {
+    "account_status": "inactive"
+  },
+  "meta": {
+    "error": "Account invalid"
+  }
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="inactive-account-status-response" raw=data-raw %}
+
+If we are unable to verify an account status due to issues with validation providers (such as a timeout or other connectivity problems), we will return a `422 Unprocessable Entity` status code, along with an empty `object` and an `Account validation failed` `error` in the `meta` object:
 
 {% capture data-raw %}
 ```javascript
@@ -392,7 +512,7 @@ Unfortunately due to how the banking system works in the supported markets it is
 Another way to limit mispayments due to mismatched mobile providers is enabling mobile provider (telco) validation on transactions. This feature will block payouts if the mapped mobile provider (returned from an internal phone number/telco check) and the mobile provider provided in the payout details don't match.
 
 <div class="alert alert-info" markdown="1">
- **Note:** This feature is currently available for `XOF::Mobile` payouts only. Also kindly be aware that this is a paid service. Please contact our Sales Team at `corporate.sales@azafinance.com` or our Account Management team at `account.mgt@azafinance.com` to request more informations.
+ **Note:** This feature is currently available for `XOF::Mobile` and `XAF::Mobile` via `orange` payouts only. Also kindly be aware that this is a paid service. Please contact our Sales Team at `corporate.sales@azafinance.com` or our Account Management team at `account.mgt@azafinance.com` to request more informations.
 </div>
 
 To enable mobile provider validation please enable the `account_validation` trait during transaction creation (this is the same trait as for account name validation):
@@ -456,3 +576,73 @@ In both cases we will return the mobile provider in the recipient’s metadata. 
 In case the mobile provider doesn’t exist or there is a connectivity issue with the telco operator system you will receive an error with the following message: `We were not able to verify that the provided account exists. This could be a temporary error with a bank, a telco, or it can mean the provided details were incorrect. We will retry the transaction. You can also edit or cancel the payout`.
 
 Unfortunately due to how the telcos system works in the supported markets it is not always possible to differentiate an invalid mobile provider from a connectivity issue, hence we will automatically retry the mobile provider validation until we get a valid response, or the transaction is cancelled.
+
+# Account status validation in transactions flow
+
+An account status validation on transactions is also available. This feature will block payouts if the account status check returns an `inactive` status.
+
+<div class="alert alert-info" markdown="1">
+ **Note:** This feature is currently available for `XAF::Mobile` payouts with `mobile_provider` set to `mtn` only. Also kindly be aware that this is a paid service. Please contact our Sales Team at `corporate.sales@azafinance.com` or our Account Management team at `account.mgt@azafinance.com` to request more informations.
+</div>
+
+To enable account status validation please enable the `account_validation` trait during transaction creation (this is the same trait as for account name and telco validation):
+
+<div class="highlight">
+  <p class="hll"><strong>POST</strong> <code>/v1/transactions</code></p>
+</div>
+
+{% capture data-raw %}
+```javascript
+{
+   "transaction":{
+      "traits": {
+        "account_validation": true
+      },
+      // (...) additional transaction details
+   }
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="validation-trait" raw=data-raw %}
+
+We can also enable account status validation by default across all transactions created by you. If this is of interest please contact our team so we can configure your account as such. If the feature is enabled, then it can be disabled on a per-transaction basis by specifying `"account_validation": false` in the `traits` section.
+
+Once the trait is enabled we will do an account status check from the telco operator, and make sure the account is valid and active. If so we will go ahead with the payout. If not we will stop the payout and return an error message describing that the transaction will not proceed unless the recipient details are updated with a valid/active account or the transaction is canceled.
+
+In both cases we will return the account status (`active`/`inactive`) in the recipient’s metadata. For example if the account linked to the phone number you used turns out to be `inactive`, you will receive a `recipient.error` webhook with the following details:
+
+{% capture data-raw %}
+```javascript
+{
+  "webhook": "fd599451-4f3c-4045-91e1-d68ed12ffb75",
+  "event": "recipient.error",
+  "object": {
+    "editable": true,
+    "metadata": {
+      "provider_account_status_validation": {
+        "valid?": false,
+        "account_status": "inactive"
+      }
+    },
+    "payout_method": {
+      "type": "XAF::Mobile",
+      "details": {
+        "phone_number": "+237674044436",
+        "mobile_provider": "mtn",
+        // (...)
+      },
+    }
+    "state": "error",
+    "state_reason": "This account is either inactive or invalid. Please edit or cancel the transaction.",
+    // (...)
+  }
+}
+```
+{% endcapture %}
+
+{% include language-tabbar.html prefix="recipient-error" raw=data-raw %}
+
+In case there is a connectivity issue with the bank or telco operator system you will receive an error with the following message: `We were not able to verify that the provided account exists. This could be a temporary error with a bank, a telco, or it can mean the provided details were incorrect. We will retry the transaction. You can also edit or cancel the payout`.
+
+Unfortunately due to how the banks and telcos system works in the supported markets it is not always possible to differentiate an invalid account from a connectivity issue, hence we will automatically retry the account status validation until we get a valid response, or the transaction is cancelled.

--- a/_docs/changelog.md
+++ b/_docs/changelog.md
@@ -8,7 +8,11 @@ permalink: /docs/changelog/
 
 Current version of the API is `1`
 
-Current version of the SDKs is `1.36.4`
+Current version of the SDKs is `1.36.8`
+
+1.36.8
+------
+* Adds account validation support for `XAF::Mobile` in Cameroon via `orange` and `mtn`.
 
 1.36.4
 ------


### PR DESCRIPTION
BTA-15285 XAF::Mobile account validation

Changes
-------

- Adds support for `XAF::Mobile` Cameroon account validation via mobile provider (`orange`) and account status (`mtn`).
- Updates the changelog.

![Screenshot 2025-04-04 at 12 48 09](https://github.com/user-attachments/assets/e07fab9e-7ff0-4717-aaee-3d53c615be9a)

![Screenshot 2025-04-04 at 12 55 33](https://github.com/user-attachments/assets/5a993e55-befd-497b-9845-c6745eb87e98)

![Screenshot 2025-04-04 at 12 48 28](https://github.com/user-attachments/assets/917d98ce-8304-4ecc-a7c3-20106b72e8d8)

![Screenshot 2025-04-04 at 12 48 52](https://github.com/user-attachments/assets/499cf069-95b6-4ed5-814b-53b397102a98)

![Screenshot 2025-04-04 at 12 49 06](https://github.com/user-attachments/assets/8852ed18-3904-4265-bb36-39c411e9e9c5)

![Screenshot 2025-04-04 at 12 49 40](https://github.com/user-attachments/assets/4397c110-edc1-4444-975c-99f493205e73)

![Screenshot 2025-04-04 at 12 49 31](https://github.com/user-attachments/assets/2e839db6-3c42-4625-8373-67c6a8075390)

![Screenshot 2025-04-04 at 13 08 26](https://github.com/user-attachments/assets/061bef82-a266-4008-a500-1fbd0f082930)

